### PR TITLE
feat: separate pull requests per package in the workspace

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -50,6 +50,7 @@
         "git_release_type": null,
         "git_tag_enable": null,
         "git_tag_name": null,
+        "one_pr_per_package": null,
         "pr_body": null,
         "pr_branch_prefix": null,
         "pr_draft": false,
@@ -603,6 +604,14 @@
           "description": "Tera template of the git tag name created by release-plz.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "one_pr_per_package": {
+          "title": "One PR per Package",
+          "description": "- If `true`, create a separate PR for every package. - If `false` or [`Option::None`], a single PR releasing all packages at once.",
+          "type": [
+            "boolean",
             "null"
           ]
         },

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -125,6 +125,10 @@ pub struct Workspace {
     /// - If `true`, update all the dependencies in the Cargo.lock file by running `cargo update`.
     /// - If `false` or [`Option::None`], only update the workspace packages by running `cargo update --workspace`.
     pub dependencies_update: Option<bool>,
+    /// # One PR per Package
+    /// - If `true`, create a separate PR for every package.
+    /// - If `false` or [`Option::None`], a single PR releasing all packages at once.
+    pub one_pr_per_package: Option<bool>,
     /// # PR Name
     /// Tera template of the pull request's name created by release-plz.
     pub pr_name: Option<String>,
@@ -456,6 +460,7 @@ mod tests {
                 changelog_config: Some("../git-cliff.toml".into()),
                 allow_dirty: Some(false),
                 repo_url: Some("https://github.com/MarcoIeni/release-plz".parse().unwrap()),
+                one_pr_per_package: None,
                 packages_defaults: PackageConfig {
                     semver_check: None,
                     changelog_update: None,
@@ -574,6 +579,7 @@ mod tests {
                 changelog_config: Some("../git-cliff.toml".into()),
                 allow_dirty: None,
                 repo_url: Some("https://github.com/MarcoIeni/release-plz".parse().unwrap()),
+                one_pr_per_package: None,
                 pr_name: None,
                 pr_body: None,
                 pr_draft: false,

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -44,13 +44,18 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
             let cargo_metadata = cmd_args.update.cargo_metadata()?;
             let config = cmd_args.update.config()?;
             let update_request = cmd_args.update.update_request(&config, cargo_metadata)?;
-            let request = get_release_pr_req(&config, update_request)?;
-            let release_pr = release_plz_core::release_pr(&request).await?;
+            let requests = get_release_pr_reqs(&config, update_request)?;
+
+            let mut prs = vec![];
+            for request in requests.iter() {
+                let release_pr = release_plz_core::release_pr(request).await?;
+
+                if let Some(pr) = release_pr {
+                    prs.push(pr);
+                }
+            }
+
             if let Some(output_type) = cmd_args.output {
-                let prs = match release_pr {
-                    Some(pr) => vec![pr],
-                    None => vec![],
-                };
                 let prs_json = serde_json::json!({
                     "prs": prs
                 });
@@ -82,7 +87,39 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_release_pr_req(
+fn get_release_pr_reqs(
+    config: &Config,
+    update_request: UpdateRequest,
+) -> anyhow::Result<Vec<ReleasePrRequest>> {
+    if config.workspace.one_pr_per_package.unwrap_or(false)
+        && update_request.single_package().is_none()
+    {
+        let packages = update_request.cargo_metadata().workspace_packages();
+
+        packages
+            .into_iter()
+            .map(|package| {
+                let update_request = update_request
+                    .clone()
+                    .with_single_package(package.name.clone());
+
+                let release_pr_request = get_single_release_pr_req(config, update_request)?;
+
+                let branch_prefix = release_pr_request.branch_prefix().to_owned();
+
+                let release_pr_request = release_pr_request
+                    .with_branch_prefix(Some(format!("{branch_prefix}-{}", package.name)));
+
+                Ok(release_pr_request)
+            })
+            .collect()
+    } else {
+        let req = get_single_release_pr_req(config, update_request)?;
+        Ok(vec![req])
+    }
+}
+
+fn get_single_release_pr_req(
     config: &Config,
     update_request: UpdateRequest,
 ) -> anyhow::Result<ReleasePrRequest> {

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -108,7 +108,7 @@ fn get_release_pr_reqs(
                 let branch_prefix = release_pr_request.branch_prefix().to_owned();
 
                 let release_pr_request = release_pr_request
-                    .with_branch_prefix(Some(format!("{branch_prefix}-{}", package.name)));
+                    .with_branch_prefix(Some(format!("{branch_prefix}{}-", package.name)));
 
                 Ok(release_pr_request)
             })

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -47,7 +47,7 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
             let requests = get_release_pr_reqs(&config, update_request)?;
 
             let mut prs = vec![];
-            for request in requests.iter() {
+            for request in &requests {
                 let release_pr = release_plz_core::release_pr(request).await?;
 
                 if let Some(pr) = release_pr {

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -81,10 +81,14 @@ impl TestContext {
         context
     }
 
-    pub async fn merge_release_pr(&self) {
+    pub async fn merge_release_prs(&self) {
         let opened_prs = self.opened_release_prs().await;
         assert_eq!(opened_prs.len(), 1);
-        self.gitea.merge_pr_retrying(opened_prs[0].number).await;
+        self.merge_release_pr(&opened_prs[0]).await;
+    }
+
+    pub async fn merge_release_pr(&self, pr: &GitPr) {
+        self.gitea.merge_pr_retrying(pr.number).await;
         self.repo.git(&["pull"]).unwrap();
     }
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -106,7 +106,7 @@ Changes:
         .trim()
     );
 
-    context.merge_release_pr().await;
+    context.merge_release_prs().await;
     // The commit contains the PR id number
     let expected_commit = format!("{expected_title} (#1)");
     assert_eq!(
@@ -140,7 +140,7 @@ async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
 
     context.run_release_pr().success();
-    context.merge_release_pr().await;
+    context.merge_release_prs().await;
 
     let expected_tag = "v0.1.0";
 
@@ -152,7 +152,7 @@ async fn release_plz_detects_edited_readme_cargo_toml_field() {
     move_readme(&context, "move readme");
 
     context.run_release_pr().success();
-    context.merge_release_pr().await;
+    context.merge_release_prs().await;
 
     let expected_tag = "v0.1.1";
 
@@ -180,7 +180,7 @@ async fn release_plz_honors_features_always_increment_minor_flag() {
     context.write_release_plz_toml(config);
 
     context.run_release_pr().success();
-    context.merge_release_pr().await;
+    context.merge_release_prs().await;
 
     let expected_tag = "v0.1.0";
 
@@ -192,7 +192,7 @@ async fn release_plz_honors_features_always_increment_minor_flag() {
     move_readme(&context, "feat: move readme");
 
     context.run_release_pr().success();
-    context.merge_release_pr().await;
+    context.merge_release_prs().await;
 
     let expected_tag = "v0.2.0";
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -5,6 +5,57 @@ use crate::helpers::test_context::TestContext;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_creates_separate_pr_per_package() {
+    let context = TestContext::new_workspace(&["crates/one", "crates/two"]).await;
+
+    let config = r#"
+[workspace]
+one_pr_per_package = true
+    "#;
+
+    context.write_release_plz_toml(config);
+    context.run_release_pr().success();
+
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(2, opened_prs.len());
+
+    let titles = opened_prs
+        .iter()
+        .map(|pr| pr.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(titles.contains(&"chore(one): release v0.1.0"));
+    assert!(titles.contains(&"chore(two): release v0.1.0"));
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_separate_pr_per_package_uses_pr_title_option() {
+    let context = TestContext::new_workspace(&["crates/one", "crates/two"]).await;
+
+    let config = r#"
+[workspace]
+one_pr_per_package = true
+pr_name = "release: {{ package }} {{ version }}"
+    "#;
+
+    context.write_release_plz_toml(config);
+    context.run_release_pr().success();
+
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(2, opened_prs.len());
+
+    let titles = opened_prs
+        .iter()
+        .map(|pr| pr.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(titles.contains(&"release: one 0.1.0"));
+    assert!(titles.contains(&"release: two 0.1.0"));
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_should_set_custom_pr_details() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -62,6 +62,10 @@ impl ReleasePrRequest {
         self
     }
 
+    pub fn branch_prefix(&self) -> &str {
+        self.branch_prefix.as_str()
+    }
+
     pub fn with_branch_prefix(mut self, pr_branch_prefix: Option<String>) -> Self {
         if let Some(branch_prefix) = pr_branch_prefix {
             self.branch_prefix = branch_prefix;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -321,7 +321,7 @@ impl UpdateRequest {
     }
 
     pub fn single_package(&self) -> Option<&str> {
-        self.single_package.as_ref().map(|p| p.as_str())
+        self.single_package.as_deref()
     }
 
     pub fn with_single_package(self, package: String) -> Self {

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -320,6 +320,10 @@ impl UpdateRequest {
         }
     }
 
+    pub fn single_package(&self) -> Option<&str> {
+        self.single_package.as_ref().map(|p| p.as_str())
+    }
+
     pub fn with_single_package(self, package: String) -> Self {
         Self {
             single_package: Some(package),

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -71,6 +71,7 @@ the following sections:
   - [`git_release_latest`](#the-git_release_latest-field) — Publish git release as latest.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`git_tag_name`](#the-git_tag_name-field) — Customize git tag pattern.
+  - [`one_pr_per_package`](#the-one_pr_per_package-field) — Create a separate PR per package.
   - [`pr_branch_prefix`](#the-pr_branch_prefix-field) — Release PR branch prefix.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
   - [`pr_name`](#the-pr_name-field) — Customize the name of the release Pull Request.
@@ -316,6 +317,11 @@ Where:
 
 - `{{ package }}` is the name of the package.
 - `{{ version }}` is the new version of the package.
+
+#### The `one_pr_per_package` field
+
+- If `true`, release-plz creates a separate branch and PR for every package version.
+- If `false`, release-plz creates s single branch and PR combining all package releases. *(Default)*.
 
 #### The `pr_name` field
 


### PR DESCRIPTION
Adds a configuration option `one_pr_per_package` (boolean, default false). If true, release plz will open a separate PR for each package in the workspace.

The option interacts as expected with the existing templating capabilities for `{{ package }}` from the config.

Closes https://github.com/MarcoIeni/release-plz/issues/1814.