### PR TITLE
chore: update release-plz CI to use actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/cargo-assist.yml
+++ b/.github/workflows/cargo-assist.yml
@@ -18,8 +18,7 @@ jobs:
           # In forks it's not available, so use the default GITHUB_TOKEN.
           token: ${{ secrets.CARGO_ASSIST_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Cargo assist
         uses: MarcoIeni/cargo-assist@main
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
         run: docker compose up -d --wait
         working-directory: ./tests
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Run tests
         run: cargo test --all-features --workspace
 
@@ -58,8 +57,7 @@ jobs:
         with:
           tool: cargo-semver-checks@0.34
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Run tests
         run: cargo test --no-default-features --features all-static --workspace
 
@@ -70,10 +68,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -84,10 +81,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
       - name: Clippy check
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
@@ -98,8 +94,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
         with:
           components: rustfmt
       - name: Check formatting
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
         with:
           components: clippy
       - name: Clippy check

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@f521df9e10ecb5687aae7cff2ddd016af4b17998
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Run release-plz
         uses: release-plz/action@main
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@f521df9e10ecb5687aae7cff2ddd016af4b17998
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@main
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Run release-plz
         uses: release-plz/action@main
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Install Rust toolchain
-        actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8
       - name: Run release-plz
         uses: release-plz/action@main
         with:

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -124,6 +124,7 @@ async fn release_plz_should_fail_for_multi_package_pr() {
 
 #[tokio::test]
 #[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
+// #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -123,8 +123,7 @@ async fn release_plz_should_fail_for_multi_package_pr() {
 }
 
 #[tokio::test]
-#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
-#[cfg_attr(not(feature = "docker-tests"), ignore)]
+#[cfg_attr(not(feature = "docker-tests"), ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this.")]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -158,7 +158,7 @@ async fn release_plz_detects_edited_readme_cargo_toml_field() {
 
 #[tokio::test]
 #[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
-#[cfg_attr(not(feature = "docker-tests"), ignore)]
+// #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_honors_features_always_increment_minor_flag() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -123,7 +123,10 @@ async fn release_plz_should_fail_for_multi_package_pr() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "docker-tests"), ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this.")]
+#[cfg_attr(
+    not(feature = "docker-tests"),
+    ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."
+)]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -123,10 +123,7 @@ async fn release_plz_should_fail_for_multi_package_pr() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    not(feature = "docker-tests"),
-    ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."
-)]
+#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
 


### PR DESCRIPTION

This pull request updates the `release-plz` CI workflow to replace the use of `dtolnay/rust-toolchain` with `actions-rust-lang/setup-rust-toolchain`. This change provides several advantages, including:

- **Caching support:** Speeds up CI runs by utilizing Rust cache effectively.
- **Support for `rust-toolchain` file:** Automatically picks the Rust version specified in the `rust-toolchain` file.
- **Ability to pin to a specific commit:** Ensures stability in CI environments.
- **Problem matcher integration:** Improves developer experience by highlighting errors inline in GitHub.

#### Changes:
1. Updated the `Install Rust toolchain` step in the `release-plz-release` and `release-plz-pr` jobs to use `actions-rust-lang/setup-rust-toolchain@<latest-commit-sha>`.
2. Pinned the action to a specific commit SHA for stability.

#### References:
- See #1832 
- [actions-rust-lang/setup-rust-toolchain documentation](https://github.com/actions-rust-lang/setup-rust-toolchain).


