### PR TITLE
♻️ refactor: use tera template for default PR body

### DIFF
--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -70,6 +70,7 @@ async fn release_plz_opens_pr_with_two_packages_and_default_config() {
 
 <details><summary><i><b>Changelog</b></i></summary><p>
 
+## `{one}`
 <blockquote>
 
 ## [0.1.0](https://localhost/{username}/{one}/releases/tag/v0.1.0) - {today}
@@ -79,6 +80,9 @@ async fn release_plz_opens_pr_with_two_packages_and_default_config() {
 - cargo init
 - Initial commit
 </blockquote>
+
+## `{two}`
+<blockquote>
 
 ## [0.1.0](https://localhost/{username}/{two}/releases/tag/v0.1.0) - {today}
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -46,6 +46,60 @@ This PR was generated with [release-plz](https://github.com/release-plz/release-
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_opens_pr_with_two_packages_and_default_config() {
+    let one = "one";
+    let two = "two";
+    let context =
+        TestContext::new_workspace(&[&format!("crates/{one}"), &format!("crates/{two}")]).await;
+
+    context.run_release_pr().success();
+
+    let opened_prs = context.opened_release_prs().await;
+    let today = today();
+    assert_eq!(opened_prs.len(), 1);
+    assert_eq!(opened_prs[0].title, "chore: release v0.1.0");
+    let username = context.gitea.user.username();
+    assert_eq!(
+        opened_prs[0].body.as_ref().unwrap().trim(),
+        format!(
+            r#"
+## 🤖 New release
+
+* `{one}`: 0.1.0
+* `{two}`: 0.1.0
+
+<details><summary><i><b>Changelog</b></i></summary><p>
+
+<blockquote>
+
+## [0.1.0](https://localhost/{username}/{one}/releases/tag/v0.1.0) - {today}
+
+### Other
+
+- cargo init
+- Initial commit
+</blockquote>
+
+## [0.1.0](https://localhost/{username}/{two}/releases/tag/v0.1.0) - {today}
+
+### Other
+
+- cargo init
+- Initial commit
+</blockquote>
+
+
+</p></details>
+
+---
+This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)."#,
+        )
+        .trim()
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_should_set_custom_pr_details() {
     let context = TestContext::new().await;
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -59,6 +59,7 @@ async fn release_plz_opens_pr_with_two_packages_and_default_config() {
     assert_eq!(opened_prs.len(), 1);
     assert_eq!(opened_prs[0].title, "chore: release v0.1.0");
     let username = context.gitea.user.username();
+    let repo = &context.gitea.repo;
     assert_eq!(
         opened_prs[0].body.as_ref().unwrap().trim(),
         format!(
@@ -71,25 +72,25 @@ async fn release_plz_opens_pr_with_two_packages_and_default_config() {
 <details><summary><i><b>Changelog</b></i></summary><p>
 
 ## `{one}`
+
 <blockquote>
 
-## [0.1.0](https://localhost/{username}/{one}/releases/tag/v0.1.0) - {today}
+## [0.1.0](https://localhost/{username}/{repo}/releases/tag/{one}-v0.1.0) - {today}
 
 ### Other
 
 - cargo init
-- Initial commit
 </blockquote>
 
 ## `{two}`
+
 <blockquote>
 
-## [0.1.0](https://localhost/{username}/{two}/releases/tag/v0.1.0) - {today}
+## [0.1.0](https://localhost/{username}/{repo}/releases/tag/{two}-v0.1.0) - {today}
 
 ### Other
 
 - cargo init
-- Initial commit
 </blockquote>
 
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -21,6 +21,7 @@ async fn release_plz_opens_pr_with_default_config() {
         format!(
             r#"
 ## 🤖 New release
+
 * `{package}`: 0.1.0
 
 <details><summary><i><b>Changelog</b></i></summary><p>

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -192,7 +192,7 @@ async fn open_or_update_release_pr(
             project_contains_multiple_pub_packages,
             &release_pr_options.pr_branch_prefix,
             release_pr_options.pr_name,
-            release_pr_options.pr_body,
+            release_pr_options.pr_body.as_deref(),
         )
         .mark_as_draft(release_pr_options.draft)
         .with_labels(release_pr_options.pr_labels)

--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -51,8 +51,8 @@ impl PackagesUpdate {
 #[derive(Serialize, Deserialize)]
 pub struct ReleaseInfo {
     package: String,
-    title: Option<String>,
-    changelog: Option<String>,
+    pub title: Option<String>,
+    pub changelog: Option<String>,
     previous_version: String,
     next_version: String,
     /// Summary of breaking changes of the release

--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -85,42 +85,6 @@ impl PackagesUpdate {
             .collect()
     }
 
-    /// Return the list of changes in the changelog of the updated packages
-    pub fn changes(&self, project_contains_multiple_pub_packages: bool) -> String {
-        self.updates
-            .iter()
-            .map(|(package, update)| match update.last_changes() {
-                Ok(Some(release)) => {
-                    let entry_prefix = if project_contains_multiple_pub_packages {
-                        format!("## `{}`\n", package.name)
-                    } else {
-                        "".to_string()
-                    };
-                    format!(
-                        "{}<blockquote>\n\n## {}\n\n{}\n</blockquote>\n\n",
-                        entry_prefix,
-                        release.title(),
-                        release.notes()
-                    )
-                }
-                Ok(None) => {
-                    warn!(
-                        "no changes detected in changelog of package {}",
-                        package.name
-                    );
-                    "".to_string()
-                }
-                Err(e) => {
-                    warn!(
-                        "can't determine changes in changelog of package {}: {e:?}",
-                        package.name
-                    );
-                    "".to_string()
-                }
-            })
-            .collect()
-    }
-
     pub fn breaking_changes(&self) -> String {
         self.updates
             .iter()
@@ -136,14 +100,28 @@ impl PackagesUpdate {
             .collect()
     }
 
+    /// Return info about releases of the updated packages
     pub fn releases(&self) -> Vec<ReleaseInfo> {
         self.updates
             .iter()
             .map(|(package, update)| {
-                let changelog = update.last_changes().unwrap_or(None);
-                let (changelog_title, changelog_notes) = changelog.map_or((None, None), |c| {
-                    (Some(c.title().to_string()), Some(c.notes().to_string()))
-                });
+                let (changelog_title, changelog_notes) = match update.last_changes() {
+                    Err(e) => {
+                        warn!(
+                            "can't determine changes in changelog of package {}: {e:?}",
+                            package.name
+                        );
+                        (None, None)
+                    }
+                    Ok(Some(c)) => (Some(c.title().to_string()), Some(c.notes().to_string())),
+                    Ok(None) => {
+                        warn!(
+                            "no changes detected in changelog of package {}",
+                            package.name
+                        );
+                        (None, None)
+                    }
+                };
 
                 let breaking_changes = match &update.semver_check {
                     SemverCheck::Incompatible(incompatibilities) => {
@@ -359,138 +337,4 @@ fn update_dependencies(
         local_manifest.write()?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn changelog_is_printed_correctly_in_workspace() {
-        test_logs::init();
-        let changelog = r#"
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [1.1.1] - 2015-05-15
-
-### Fixed
-- myfix
-
-### Other
-- simple update
-
-## [1.1.0] - 1970-01-01
-
-### fix bugs
-- my awesomefix
-
-### other
-- complex update
-        "#
-        .to_string();
-        let pkgs = PackagesUpdate::new(vec![
-            (
-                fake_package::FakePackage::new("foo").into(),
-                UpdateResult {
-                    version: Version::parse("0.2.0").unwrap(),
-                    changelog: Some(changelog.clone()),
-                    semver_check: SemverCheck::Compatible,
-                },
-            ),
-            (
-                fake_package::FakePackage::new("bar").into(),
-                UpdateResult {
-                    version: Version::parse("0.2.0").unwrap(),
-                    changelog: Some(changelog),
-                    semver_check: SemverCheck::Compatible,
-                },
-            ),
-        ]);
-        expect_test::expect![[r#"
-            ## `foo`
-            <blockquote>
-
-            ## [1.1.1] - 2015-05-15
-
-            ### Fixed
-            - myfix
-
-            ### Other
-            - simple update
-            </blockquote>
-
-            ## `bar`
-            <blockquote>
-
-            ## [1.1.1] - 2015-05-15
-
-            ### Fixed
-            - myfix
-
-            ### Other
-            - simple update
-            </blockquote>
-
-        "#]]
-        .assert_eq(&pkgs.changes(true));
-    }
-
-    #[test]
-    fn changelog_is_printed_correctly() {
-        test_logs::init();
-        let changelog = r#"
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [1.1.1] - 2015-05-15
-
-### Fixed
-- myfix
-
-### Other
-- simple update
-
-## [1.1.0] - 1970-01-01
-
-### fix bugs
-- my awesomefix
-
-### other
-- complex update
-        "#
-        .to_string();
-        let pkgs = PackagesUpdate::new(vec![(
-            fake_package::FakePackage::new("foo").into(),
-            UpdateResult {
-                version: Version::parse("0.2.0").unwrap(),
-                changelog: Some(changelog),
-                semver_check: SemverCheck::Compatible,
-            },
-        )]);
-        expect_test::expect![[r#"
-            <blockquote>
-
-            ## [1.1.1] - 2015-05-15
-
-            ### Fixed
-            - myfix
-
-            ### Other
-            - simple update
-            </blockquote>
-
-        "#]]
-        .assert_eq(&pkgs.changes(false));
-    }
 }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -8,8 +8,8 @@ pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"
 {% macro get_changes(releases, type="text") %}
-    {%- for release in releases %}
-    {%- if release.title and release.changelog %}{% if releases | length > 1 %}
+{%- for release in releases %}
+{%- if release.title and release.changelog %}{% if releases | length > 1 %}
 ## `{{ release.package }}`
 {% endif %}
 <blockquote>

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -52,7 +52,7 @@ impl Pr {
         project_contains_multiple_pub_packages: bool,
         branch_prefix: &str,
         title_template: Option<String>,
-        body_template: Option<String>,
+        body_template: Option<&str>,
     ) -> Self {
         Self {
             branch: release_branch(branch_prefix),
@@ -135,12 +135,9 @@ fn pr_title(
 /// The Github API allows a max of 65536 characters in the body field when trying to create a new PR
 const MAX_BODY_LEN: usize = 65536;
 
-fn pr_body(packages_to_update: &PackagesUpdate, body_template: Option<String>) -> String {
-    let body_template = body_template.unwrap_or(DEFAULT_PR_BODY_TEMPLATE.to_string());
-    pr_body_custom(packages_to_update, body_template.as_str())
-}
+fn pr_body(packages_to_update: &PackagesUpdate, body_template: Option<&str>) -> String {
+    let body_template = body_template.unwrap_or(DEFAULT_PR_BODY_TEMPLATE);
 
-fn pr_body_custom(packages_to_update: &PackagesUpdate, body_template: &str) -> String {
     let mut releases = packages_to_update.releases();
     let first_render = render_pr_body(&releases, body_template);
 

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -14,9 +14,8 @@ pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
 <details><summary><i><b>Changelog</b></i></summary><p>
 
 <blockquote>
-
 {% if release.title %}
-{{release.title}}
+## {{release.title}}
 {% endif %}
 {% if release.changelog %}
 {{release.changelog}}

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -7,27 +7,21 @@ use chrono::SecondsFormat;
 pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
-
-{% for release in releases %}
-* `{{release.package}}`: {{release.next_version}}
+{%- for release in releases %}
+* `{{ release.package }}`: {{ release.next_version }}
 
 <details><summary><i><b>Changelog</b></i></summary><p>
 
 <blockquote>
-{% if release.title %}
-## {{release.title}}
-{% endif %}
-{% if release.changelog %}
-{{release.changelog}}
-{% endif %}
-{% if release.breaking_changes %}
-### ⚠️ Breaking Changes
-{{release.breaking_changes}}
-{% endif %}
+## [{{ release.next_version }}]({{ release.release_link }}) - {{ release.date }}
+
+### Other
+
+{{ release.changelog | indent(4) }}
 </blockquote>
 
 </p></details>
-{% endfor %}
+{%- endfor %}
 
 ---
 This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)."#;

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -9,10 +9,15 @@ pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
 
 {% for release in releases %}
+* `{{release.package}}`: {{release.next_version}}
+
+<details><summary><i><b>Changelog</b></i></summary><p>
+
+<blockquote>
+
 {% if release.title %}
-### {{release.title}}
+{{release.title}}
 {% endif %}
-Package: {{release.package}} {{release.previous_version}} -> {{release.next_version}}
 {% if release.changelog %}
 {{release.changelog}}
 {% endif %}
@@ -20,10 +25,13 @@ Package: {{release.package}} {{release.previous_version}} -> {{release.next_vers
 ### ⚠️ Breaking Changes
 {{release.breaking_changes}}
 {% endif %}
+</blockquote>
+
+</p></details>
 {% endfor %}
 
 ---
-*This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)*"#;
+This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)."#;
 
 #[derive(Debug)]
 pub struct Pr {

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -7,17 +7,15 @@ use chrono::SecondsFormat;
 pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
-{%- for release in releases %}
+{% for release in releases %}
 * `{{ release.package }}`: {{ release.next_version }}
 
 <details><summary><i><b>Changelog</b></i></summary><p>
 
 <blockquote>
-## [{{ release.next_version }}]({{ release.release_link }}) - {{ release.date }}
 
-### Other
+{{ release.changelog }}
 
-{{ release.changelog | indent(4) }}
 </blockquote>
 
 </p></details>

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -62,10 +62,7 @@ impl Pr {
                 project_contains_multiple_pub_packages,
                 title_template,
             ),
-            body: pr_body(
-                packages_to_update,
-                body_template,
-            ),
+            body: pr_body(packages_to_update, body_template),
             draft: false,
             labels: vec![],
         }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -7,14 +7,23 @@ use chrono::SecondsFormat;
 pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
-{{ summary }}
-<details><summary><i><b>Changelog</b></i></summary><p>
 
-{{ changes }}
-</p></details>
+{% for release in releases %}
+{% if release.title %}
+### {{release.title}}
+{% endif %}
+Package: {{release.package}} {{release.previous_version}} -> {{release.next_version}}
+{% if release.changelog %}
+{{release.changelog}}
+{% endif %}
+{% if release.breaking_changes %}
+### ⚠️ Breaking Changes
+{{release.breaking_changes}}
+{% endif %}
+{% endfor %}
 
 ---
-This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)."#;
+*This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)*"#;
 
 #[derive(Debug)]
 pub struct Pr {

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -6,12 +6,11 @@ use chrono::SecondsFormat;
 
 pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
-pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release{{ summary }}
-
+pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"## 🤖 New release
+{{ summary }}
 <details><summary><i><b>Changelog</b></i></summary><p>
 
 {{ changes }}
-
 </p></details>
 
 ---

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -366,8 +366,9 @@ pr_name = "release: {{ package }} {{ version }}"
 release-plz creates.
 
 By default it contains the summary of package updates, the changelog for each package, a section
-for breaking changes, and a footer with credits for release-plz. The text is trimmed to a length
-of 65536, because that's the limit imposed by Github.
+for breaking changes, and a footer with credits for release-plz. If the text is longer than
+65536 characters, the changelog isn't inclued.
+This limit is imposed by Github.
 
 Here is an example of how you can customize the PR body template:
 
@@ -404,6 +405,41 @@ to check for their existence.
 - `{{ release.next_version }}` - the version of the package being released.
 - `{{ release.breaking_changes }}` - the summary of the breaking changes of the package being
   released. *(Optional)*.
+
+The default PR body template is the following:
+
+```toml
+[workspace]
+pr_body = """
+{% macro get_changes(releases, type="text") %}
+{%- for release in releases %}
+{%- if release.title and release.changelog %}{% if releases | length > 1 %}
+## `{{ release.package }}`
+{% endif %}
+<blockquote>
+
+## {{ release.title }}
+
+{{ release.changelog }}
+</blockquote>{% endif %}
+{% endfor %}
+{% endmacro -%}
+
+{% set changes = self::get_changes(releases=releases) %}
+
+## 🤖 New release
+{% for release in releases %}
+* `{{ release.package }}`: {{ release.next_version }}
+{%- endfor %}
+{% if changes %}
+<details><summary><i><b>Changelog</b></i></summary><p>
+{{ changes }}
+</p></details>
+{% endif %}
+---
+This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
+"""
+```
 
 #### The `pr_branch_prefix` field
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->
closes #1788 

1. Moved the default PR body template to a constant
2. Using Tera templating  for both default and custom templates
3. Simplifying the `pr_body_default` function
