### PR TITLE
Fix elided lifetime issue

### DIFF
--- a/crates/release_plz/src/args/repo_command.rs
+++ b/crates/release_plz/src/args/repo_command.rs
@@ -22,7 +22,7 @@ pub trait RepoCommand: ManifestCommand {
     }
 
     /// Repo url specified by user
-    fn user_repo_url<'a>(&'a self, config: &'a Config) -> Option<&str> {
+    fn user_repo_url<'a>(&'a self, config: &'a Config) -> Option<&'a str> {
         self.repo_url()
             .or_else(|| config.workspace.repo_url.as_ref().map(|u| u.as_str()))
     }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
#### Summary of Change:

Added a lifetime to the return type of `user_repo_url` trait func. The compiler requires explicit lifetimes because the function takes references from both `self` and `config`, and it cannot safely infer which input's lifetime the output depends on.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
