### PR TITLE
feat: Enable `pr_labels` for GitLab backend

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -421,7 +421,7 @@ Before changing the release-plz branch you should close the old release PR.
 #### The `pr_labels` field
 
 Add labels to the Pull Request opened by release-plz.
-*(GitHub only)*.
+*(GitHub and GitLab only)*.
 
 Example:
 


### PR DESCRIPTION
See <https://docs.gitlab.com/ee/api/merge_requests.html#update-mr>.

<!-- Please explain the changes you made -->

Use the [GitLab Merge Request API](https://docs.gitlab.com/ee/api/merge_requests.html#update-mr) to add the labels to the merge request.

It is also possible to add the labels on merge request creation, but to keep the program flow the same, I have decided to use the "update an existing merge request" endpoint to match the GitHub version.

I decided to use the `add_labels` parameter instead of `labels`, since the `labels` parameter can be destructive (in the sense that it can remove labels from a merge request).

I have tested this successfully in a private GitLab repo, and can't think of a way to add automated testing for this.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
