### PR TITLE
fix: locate Cargo.lock correctly when project isn't in root directory

### DIFF
--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -24,7 +24,7 @@ pub struct Project {
     packages: Vec<Package>,
     /// Metadata for each release enabled package.
     release_metadata: HashMap<String, ReleaseMetadata>,
-    /// Project root directory
+    /// Project root directory, i.e. where `.git` is located.
     root: Utf8PathBuf,
     /// Directory containing the project manifest
     manifest_dir: Utf8PathBuf,
@@ -157,7 +157,7 @@ impl Project {
     }
 
     pub fn cargo_lock_path(&self) -> Utf8PathBuf {
-        self.root.join("Cargo.lock")
+        self.manifest_dir.join("Cargo.lock")
     }
 
     // Check mandatory fields for crates.io


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Fix bug described in https://github.com/release-plz/release-plz/pull/1855 