### PR TITLE
feat: allow adding labels to Gitea release PR

### DIFF
--- a/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
+++ b/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
@@ -41,11 +41,16 @@ pub async fn create_token(user: &GiteaUser, client: &reqwest::Client) -> String 
         .basic_auth(user.username(), Some(&user.password()))
         .json(&json!({
             "name": user.username(),
-            // write:repository, write:user - edit repositories
-            // write:package - publish packages (for cargo publish)
-            // read:issue, write:issue - read and edit issues (to add a label to the release PR)
-            "scopes": ["read:repository", "write:repository", "write:user",
-                        "write:package", "read:issue", "write:issue"]
+            "scopes": [
+                // to create git tags and releases.
+                "read:repository", "write:repository",
+                // to create a new repository.
+                "write:user",
+                // to publish packages (i.e. cargo publish)
+                "write:package",
+                // to add a label to the release PR
+                "read:issue", "write:issue"
+            ]
         }))
         .send()
         .await

--- a/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
+++ b/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
@@ -43,6 +43,7 @@ pub async fn create_token(user: &GiteaUser, client: &reqwest::Client) -> String 
             "name": user.username(),
             // write:repository, write:user - edit repositories
             // write:package - publish packages (for cargo publish)
+            // read:issue - read issues (to add a label to the release PR)
             "scopes": ["read:repository", "write:repository", "write:user",
                         "write:package", "read:issue", "write:issue"]
         }))

--- a/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
+++ b/crates/release_plz/tests/all/helpers/gitea/gitea_new.rs
@@ -43,7 +43,7 @@ pub async fn create_token(user: &GiteaUser, client: &reqwest::Client) -> String 
             "name": user.username(),
             // write:repository, write:user - edit repositories
             // write:package - publish packages (for cargo publish)
-            // read:issue - read issues (to add a label to the release PR)
+            // read:issue, write:issue - read and edit issues (to add a label to the release PR)
             "scopes": ["read:repository", "write:repository", "write:user",
                         "write:package", "read:issue", "write:issue"]
         }))

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -279,7 +279,7 @@ async fn release_plz_doesnt_add_invalid_labels_to_release_pr() {
             [workspace]
             pr_labels = [" "]
         "#,
-            "Empty labels are not allowed",
+            "leading or trailing whitespace is not allowed",
         ), // space label
         (
             r#"

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -294,7 +294,14 @@ async fn release_plz_doesnt_add_invalid_labels_to_release_pr() {
             pr_labels = [""]
             "#,
             "Empty labels are not allowed",
-        ), // empty label
+        ),
+        (
+            r#"
+            [workspace]
+            pr_labels = ["abc", "abc"]
+            "#,
+            "duplicate labels are not allowed",
+        ),
     ];
 
     for test_case in test_cases {

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -218,7 +218,7 @@ async fn changelog_is_not_updated_if_version_already_exists_in_changelog() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_add_labels_to_release_pull_request() {
+async fn release_plz_adds_labels_to_release_pr() {
     let test_context = TestContext::new().await;
 
     // Initial PR setup with two labels
@@ -270,7 +270,7 @@ async fn release_plz_add_labels_to_release_pull_request() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_add_duplicate_labels_to_release_pr() {
+async fn release_plz_adds_deduplicated_labels_in_release_pr() {
     let test_context = TestContext::new().await;
     let duplicate_config_test_cases = r#"
             [workspace]
@@ -294,7 +294,7 @@ async fn release_plz_add_duplicate_labels_to_release_pr() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_add_invalid_labels_to_release_pr() {
+async fn release_plz_doesnt_add_invalid_labels_to_release_pr() {
     let test_context = TestContext::new().await;
     let test_cases: &[(&str, &str)] = &[
         // (label config, expected error message)

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -270,30 +270,6 @@ async fn release_plz_adds_labels_to_release_pr() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_adds_deduplicated_labels_in_release_pr() {
-    let test_context = TestContext::new().await;
-    let duplicate_config_test_cases = r#"
-            [workspace]
-            pr_labels = ["feature", "Feature", "FEATURE"]
-            "#; // initial release pr
-    let duplicate_config2_test_cases = r#"
-            [workspace]
-            pr_labels = ["feature", "FEATURE", "Bug", "urgent"]
-            "#; // update release pr
-
-    test_context.write_release_plz_toml(duplicate_config_test_cases);
-    test_context.run_release_pr().success();
-    let mut prs = test_context.opened_release_prs().await;
-    assert_eq!(prs[0].labels.len(), 3, "Expected 2 labels to get created");
-
-    test_context.write_release_plz_toml(duplicate_config2_test_cases);
-    test_context.run_release_pr().success();
-    prs = test_context.opened_release_prs().await;
-    assert_eq!(prs[0].labels.len(), 5, "Expected 3 labels to get created");
-}
-
-#[tokio::test]
-#[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_doesnt_add_invalid_labels_to_release_pr() {
     let test_context = TestContext::new().await;
     let test_cases: &[(&str, &str)] = &[

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -284,12 +284,12 @@ async fn release_plz_adds_deduplicated_labels_in_release_pr() {
     test_context.write_release_plz_toml(duplicate_config_test_cases);
     test_context.run_release_pr().success();
     let mut prs = test_context.opened_release_prs().await;
-    assert_eq!(prs[0].labels.len(), 1, "Expected 2 labels to get created");
+    assert_eq!(prs[0].labels.len(), 3, "Expected 2 labels to get created");
 
     test_context.write_release_plz_toml(duplicate_config2_test_cases);
     test_context.run_release_pr().success();
     prs = test_context.opened_release_prs().await;
-    assert_eq!(prs[0].labels.len(), 3, "Expected 3 labels to get created");
+    assert_eq!(prs[0].labels.len(), 5, "Expected 3 labels to get created");
 }
 
 #[tokio::test]

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -270,6 +270,30 @@ async fn release_plz_add_labels_to_release_pull_request() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_add_duplicate_labels_to_release_pr() {
+    let test_context = TestContext::new().await;
+    let duplicate_config_test_cases = r#"
+            [workspace]
+            pr_labels = ["feature", "Feature", "FEATURE"]
+            "#; // initial release pr
+    let duplicate_config2_test_cases = r#"
+            [workspace]
+            pr_labels = ["feature", "FEATURE", "Bug", "urgent"]
+            "#; // update release pr
+
+    test_context.write_release_plz_toml(duplicate_config_test_cases);
+    test_context.run_release_pr().success();
+    let mut prs = test_context.opened_release_prs().await;
+    assert_eq!(prs[0].labels.len(), 1, "Expected 2 labels to get created");
+
+    test_context.write_release_plz_toml(duplicate_config2_test_cases);
+    test_context.run_release_pr().success();
+    prs = test_context.opened_release_prs().await;
+    assert_eq!(prs[0].labels.len(), 3, "Expected 3 labels to get created");
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_add_invalid_labels_to_release_pr() {
     let test_context = TestContext::new().await;
     let test_cases: &[(&str, &str)] = &[

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -222,11 +222,11 @@ async fn release_plz_add_labels_to_release_pull_request() {
     let test_context = TestContext::new().await;
 
     // Initial PR setup with two labels
-    let initial_config: &str = r#"
+    let initial_config = r#"
     [workspace]
     pr_labels = ["bug", "enhancement"]
     "#;
-    let initial_labels: [&str; 2] = ["bug", "enhancement"];
+    let initial_labels = ["bug", "enhancement"];
 
     test_context.write_release_plz_toml(initial_config);
     test_context.run_release_pr().success();
@@ -237,20 +237,18 @@ async fn release_plz_add_labels_to_release_pull_request() {
     let initial_pr = &initial_prs[0];
     assert_eq!(initial_pr.labels.len(), 2, "Expected 2 labels");
 
-    let initial_label_names: Vec<String> =
-        initial_pr.labels.iter().map(|l| l.name.clone()).collect();
     assert_eq!(
-        initial_label_names, initial_labels,
+        initial_pr.label_names(), initial_labels,
         "Labels don't match expected values"
     );
 
     // Update PR with additional label
-    let updated_config: &str = r#"
+    let updated_config = r#"
     [workspace]
     pr_name = "add labels to release label update"
     pr_labels = ["needs-testing"]
     "#;
-    let expected_labels: [&str; 3] = ["bug", "enhancement", "needs-testing"];
+    let expected_labels = ["bug", "enhancement", "needs-testing"];
 
     test_context.write_release_plz_toml(updated_config);
     test_context.run_release_pr().success();

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -236,17 +236,10 @@ async fn release_plz_add_labels_to_release_pull_request() {
     assert_eq!(initial_prs.len(), 1, "Expected one PR to be created");
 
     let initial_pr = &initial_prs[0];
-    assert_eq!(
-        initial_pr.labels.len(),
-        2,
-        "Expected 2 labels"
-    );
+    assert_eq!(initial_pr.labels.len(), 2, "Expected 2 labels");
 
-    let initial_label_names: Vec<String> = initial_pr
-        .labels
-        .iter()
-        .map(|l| l.name.clone())
-        .collect();
+    let initial_label_names: Vec<String> =
+        initial_pr.labels.iter().map(|l| l.name.clone()).collect();
     assert_eq!(
         initial_label_names, initial_labels,
         "Labels don't match expected values"
@@ -268,17 +261,10 @@ async fn release_plz_add_labels_to_release_pull_request() {
 
     let updated_pr = &updated_prs[0];
     assert_eq!(updated_pr.title, "add labels to release label update");
-    assert_eq!(
-        updated_pr.labels.len(),
-        3,
-        "Expected 3 labels after update"
-    );
+    assert_eq!(updated_pr.labels.len(), 3, "Expected 3 labels after update");
 
-    let updated_label_names: Vec<String> = updated_pr
-        .labels
-        .iter()
-        .map(|l| l.name.clone())
-        .collect();
+    let updated_label_names: Vec<String> =
+        updated_pr.labels.iter().map(|l| l.name.clone()).collect();
     assert_eq!(
         updated_label_names, expected_labels,
         "Updated labels don't match expected values"

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -238,7 +238,8 @@ async fn release_plz_add_labels_to_release_pull_request() {
     assert_eq!(initial_pr.labels.len(), 2, "Expected 2 labels");
 
     assert_eq!(
-        initial_pr.label_names(), initial_labels,
+        initial_pr.label_names(),
+        initial_labels,
         "Labels don't match expected values"
     );
 
@@ -260,10 +261,9 @@ async fn release_plz_add_labels_to_release_pull_request() {
     assert_eq!(updated_pr.title, "add labels to release label update");
     assert_eq!(updated_pr.labels.len(), 3, "Expected 3 labels after update");
 
-    let updated_label_names: Vec<String> =
-        updated_pr.labels.iter().map(|l| l.name.clone()).collect();
     assert_eq!(
-        updated_label_names, expected_labels,
+        updated_pr.label_names(),
+        expected_labels,
         "Updated labels don't match expected values"
     );
 }

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -237,15 +237,13 @@ async fn release_plz_add_labels_to_release_pull_request() {
 
     let initial_pr = &initial_prs[0];
     assert_eq!(
-        initial_pr.labels.as_ref().unwrap().len(),
+        initial_pr.labels.len(),
         2,
         "Expected 2 labels"
     );
 
     let initial_label_names: Vec<String> = initial_pr
         .labels
-        .as_ref()
-        .unwrap()
         .iter()
         .map(|l| l.name.clone())
         .collect();
@@ -271,15 +269,13 @@ async fn release_plz_add_labels_to_release_pull_request() {
     let updated_pr = &updated_prs[0];
     assert_eq!(updated_pr.title, "add labels to release label update");
     assert_eq!(
-        updated_pr.labels.as_ref().unwrap().len(),
+        updated_pr.labels.len(),
         3,
         "Expected 3 labels after update"
     );
 
     let updated_label_names: Vec<String> = updated_pr
         .labels
-        .as_ref()
-        .unwrap()
         .iter()
         .map(|l| l.name.clone())
         .collect();

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -286,7 +286,7 @@ async fn release_plz_add_invalid_labels_to_release_pr() {
             [workspace]
             pr_labels = ["this-is-a-very-long-label-that-exceeds-the-maximum-length-allowed-by-git-providers"]
             "#,
-            "Label exceeds maximum length of 50 characters",
+            "it exceeds maximum length of 50 characters",
         ), // Too long
         (
             r#"
@@ -302,7 +302,7 @@ async fn release_plz_add_invalid_labels_to_release_pr() {
         test_context.write_release_plz_toml(initial_config);
         let error = test_context.run_release_pr().failure().to_string();
         assert!(
-            error.contains("Failed to add labels") && error.contains(test_case.1),
+            error.contains("Failed to add label") && error.contains(test_case.1),
             "Expected label creation failure got: {error}"
         );
     }

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1,7 +1,7 @@
+use crate::helpers::test_context::TestContext;
 use cargo_utils::LocalManifest;
 use chrono::Local;
 use std::string::String;
-use crate::helpers::test_context::TestContext;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
@@ -236,13 +236,23 @@ async fn release_plz_add_labels_to_release_pull_request() {
     assert_eq!(initial_prs.len(), 1, "Expected one PR to be created");
 
     let initial_pr = &initial_prs[0];
-    assert_eq!(initial_pr.labels.as_ref().unwrap().len(), 2, "Expected 2 labels");
+    assert_eq!(
+        initial_pr.labels.as_ref().unwrap().len(),
+        2,
+        "Expected 2 labels"
+    );
 
-    let initial_label_names: Vec<String> = initial_pr.labels.as_ref().unwrap()
+    let initial_label_names: Vec<String> = initial_pr
+        .labels
+        .as_ref()
+        .unwrap()
         .iter()
         .map(|l| l.name.clone())
         .collect();
-    assert_eq!(initial_label_names, initial_labels, "Labels don't match expected values");
+    assert_eq!(
+        initial_label_names, initial_labels,
+        "Labels don't match expected values"
+    );
 
     // Update PR with additional label
     let updated_config: &str = r#"
@@ -260,13 +270,23 @@ async fn release_plz_add_labels_to_release_pull_request() {
 
     let updated_pr = &updated_prs[0];
     assert_eq!(updated_pr.title, "add labels to release label update");
-    assert_eq!(updated_pr.labels.as_ref().unwrap().len(), 3, "Expected 3 labels after update");
+    assert_eq!(
+        updated_pr.labels.as_ref().unwrap().len(),
+        3,
+        "Expected 3 labels after update"
+    );
 
-    let updated_label_names: Vec<String> = updated_pr.labels.as_ref().unwrap()
+    let updated_label_names: Vec<String> = updated_pr
+        .labels
+        .as_ref()
+        .unwrap()
         .iter()
         .map(|l| l.name.clone())
         .collect();
-    assert_eq!(updated_label_names, expected_labels, "Updated labels don't match expected values");
+    assert_eq!(
+        updated_label_names, expected_labels,
+        "Updated labels don't match expected values"
+    );
 }
 
 #[tokio::test]
@@ -275,31 +295,37 @@ async fn release_plz_add_invalid_labels_to_release_pr() {
     let test_context = TestContext::new().await;
     let test_cases: &[(&str, &str)] = &[
         // (label config, expected error message)
-        (r#"
+        (
+            r#"
             [workspace]
             pr_labels = [" "]
-        "#, "Empty labels are not allowed"), // space label
-        (r#"
+        "#,
+            "Empty labels are not allowed",
+        ), // space label
+        (
+            r#"
             [workspace]
             pr_labels = ["this-is-a-very-long-label-that-exceeds-the-maximum-length-allowed-by-git-providers"]
-            "#, "Label exceeds maximum length of 50 characters"), // Too long
-        (r#"
+            "#,
+            "Label exceeds maximum length of 50 characters",
+        ), // Too long
+        (
+            r#"
             [workspace]
             pr_labels = [""]
-            "#, "Empty labels are not allowed"), // empty label
+            "#,
+            "Empty labels are not allowed",
+        ), // empty label
     ];
 
-    for test_case in test_cases{
+    for test_case in test_cases {
         let initial_config = test_case.0;
         test_context.write_release_plz_toml(initial_config);
         let error = test_context.run_release_pr().failure().to_string();
         assert!(
-            error.contains("Failed to add labels") &&
-                error.contains(test_case.1),
-            "Expected label creation failure got: {}",
-            error
+            error.contains("Failed to add labels") && error.contains(test_case.1),
+            "Expected label creation failure got: {error}"
         );
-
     }
 }
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1,7 +1,6 @@
 use crate::helpers::test_context::TestContext;
 use cargo_utils::LocalManifest;
 use chrono::Local;
-use std::string::String;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -123,7 +123,7 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
         let there_are_commits_to_push = repo.is_clean().is_err();
         if there_are_commits_to_push {
             if !input.labels.is_empty() {
-                validate_labels(&input.labels.clone())?
+                validate_labels(&input.labels.clone())?;
             }
             let pr = open_or_update_release_pr(
                 &local_manifest,

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -102,6 +102,7 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
         tmp_project_root_parent.path(),
     )?;
 
+    validate_labels(&input.labels)?;
     let tmp_project_root =
         new_project_root(&original_project_root, tmp_project_root_parent.path())?;
 
@@ -122,9 +123,6 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
         let repo = Repo::new(tmp_project_root)?;
         let there_are_commits_to_push = repo.is_clean().is_err();
         if there_are_commits_to_push {
-            if !input.labels.is_empty() {
-                validate_labels(&input.labels.clone())?;
-            }
             let pr = open_or_update_release_pr(
                 &local_manifest,
                 &packages_to_update,

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -316,7 +316,7 @@ async fn update_pr(
     if pr_edit.contains_edit() {
         git_client.edit_pr(opened_pr.number, pr_edit).await?;
     }
-    if !new_pr.labels.is_empty() && opened_pr.label_names() != new_pr.labels {
+    if opened_pr.label_names() != new_pr.labels {
         git_client
             .add_labels(&new_pr.labels, opened_pr.number)
             .await?;

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -4,7 +4,7 @@ use git_cmd::Repo;
 
 use anyhow::Context;
 use serde::Serialize;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 use url::Url;
 
 use crate::git::backend::{contributors_from_commits, BackendType, GitClient, GitPr, PrEdit};
@@ -313,9 +313,7 @@ async fn update_pr(
     if pr_edit.contains_edit() {
         git_client.edit_pr(opened_pr.number, pr_edit).await?;
         // add labels via pr update
-        if new_pr.labels.is_empty() {
-            warn!("No labels provided for PR #{}", opened_pr.number);
-        } else {
+        if !new_pr.labels.is_empty() {
             git_client
                 .add_labels(&new_pr.labels, opened_pr.number)
                 .await?;

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -312,12 +312,11 @@ async fn update_pr(
     };
     if pr_edit.contains_edit() {
         git_client.edit_pr(opened_pr.number, pr_edit).await?;
-        // add labels via pr update
-        if !new_pr.labels.is_empty() {
-            git_client
-                .add_labels(&new_pr.labels, opened_pr.number)
-                .await?;
-        }
+    }
+    if !new_pr.labels.is_empty() && opened_pr.label_names() != new_pr.labels {
+        git_client
+            .add_labels(&new_pr.labels, opened_pr.number)
+            .await?;
     }
     info!("updated pr {}", opened_pr.html_url);
     Ok(())

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -313,10 +313,12 @@ async fn update_pr(
     if pr_edit.contains_edit() {
         git_client.edit_pr(opened_pr.number, pr_edit).await?;
         // add labels via pr update
-        if !&new_pr.labels.is_empty() {
-            git_client.add_labels(&new_pr.labels, opened_pr.number).await?;
-        } else {
+        if new_pr.labels.is_empty() {
             warn!("No labels provided for PR #{}", opened_pr.number);
+        } else {
+            git_client
+                .add_labels(&new_pr.labels, opened_pr.number)
+                .await?;
         }
     }
     info!("updated pr {}", opened_pr.html_url);

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -7,7 +7,9 @@ use serde::Serialize;
 use tracing::{debug, info, instrument};
 use url::Url;
 
-use crate::git::backend::{contributors_from_commits, BackendType, GitClient, GitPr, PrEdit};
+use crate::git::backend::{
+    contributors_from_commits, validate_labels, BackendType, GitClient, GitPr, PrEdit,
+};
 use crate::git::github_graphql;
 use crate::pr::{Pr, DEFAULT_BRANCH_PREFIX, OLD_BRANCH_PREFIX};
 use crate::{
@@ -120,6 +122,9 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
         let repo = Repo::new(tmp_project_root)?;
         let there_are_commits_to_push = repo.is_clean().is_err();
         if there_are_commits_to_push {
+            if !input.labels.is_empty() {
+                validate_labels(&input.labels.clone())?
+            }
             let pr = open_or_update_release_pr(
                 &local_manifest,
                 &packages_to_update,

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -675,14 +675,14 @@ impl GitClient {
         let current_pr_labels: HashSet<String> =
             pr_info.labels.iter().map(|l| l.name.clone()).collect();
 
-        let mut labels_to_create = Vec::new();
+        let mut labels_to_create: Vec<String> = vec![];
         let mut label_ids = Vec::new();
 
         for label in labels {
-            match existing_label_map.get(&label) {
+            match existing_label_map.get(label) {
                 Some((original_name, id)) => {
                     // Only add the ID if the label isn't already on the PR
-                    if !current_pr_labels.contains(&label) {
+                    if !current_pr_labels.contains(label) {
                         label_ids.push(id.with_context(|| {
                             format!("failed to extract id from existing label '{original_name}'")
                         })?);
@@ -690,8 +690,8 @@ impl GitClient {
                 }
                 None => {
                     // Only create labels that don't exist
-                    if !labels_to_create.contains(&label) {
-                        labels_to_create.push(label.clone());
+                    if !labels_to_create.contains(label) {
+                        labels_to_create.push(label.to_string());
                     }
                 }
             }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -663,9 +663,7 @@ impl GitClient {
     ) -> anyhow::Result<(Vec<String>, Vec<u64>)> {
         // Fetch both existing repository labels and current PR labels concurrently
         let (existing_labels, pr_info) =
-            tokio::try_join!(async { self.get_repository_labels().await }, async {
-                self.get_pr_info(pr_number).await
-            })?;
+            tokio::try_join!(self.get_repository_labels(), self.get_pr_info(pr_number))?;
 
         // Create case-sensitive map for lookups
         let existing_label_map: HashMap<String, (String, Option<u64>)> = existing_labels

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -681,15 +681,17 @@ impl GitClient {
         for label in labels {
             match existing_label_map.get(label.as_str()) {
                 Some(l) => {
-                    // Only add the ID if the label isn't already on the PR
+                    // The label already exists in the repository.
+                    // If the label isn't already in the PR, we add it using the label ID.
                     if !current_pr_labels.contains(label.as_str()) {
+                        // The label ID is present for Gitea and GitHub
                         label_ids.push(l.id.with_context(|| {
                             format!("failed to extract id from existing label '{}'", l.name)
                         })?);
                     }
                 }
                 None => {
-                    // Only create labels that don't exist
+                    // The label doesn't exist in the repository, so we need to create it.
                     if !labels_to_create.contains(label) {
                         labels_to_create.push(label.to_string());
                     }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -665,10 +665,10 @@ impl GitClient {
         let (existing_labels, pr_info) =
             tokio::try_join!(self.get_repository_labels(), self.get_pr_info(pr_number))?;
 
-        // Create case-sensitive map for lookups
-        let existing_label_map: HashMap<String, (String, Option<u64>)> = existing_labels
+        // Create map for lookups
+        let existing_label_map: HashMap<&str, &Label> = existing_labels
             .iter()
-            .map(|l| (l.name.clone(), (l.name.clone(), l.id)))
+            .map(|l| (l.name.as_str(), l))
             .collect();
 
         // Get current PR labels
@@ -679,12 +679,12 @@ impl GitClient {
         let mut label_ids = Vec::new();
 
         for label in labels {
-            match existing_label_map.get(label) {
-                Some((original_name, id)) => {
+            match existing_label_map.get(label.as_str()) {
+                Some(l) => {
                     // Only add the ID if the label isn't already on the PR
                     if !current_pr_labels.contains(label) {
-                        label_ids.push(id.with_context(|| {
-                            format!("failed to extract id from existing label '{original_name}'")
+                        label_ids.push(l.id.with_context(|| {
+                            format!("failed to extract id from existing label '{}'", l.name)
                         })?);
                     }
                 }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -672,8 +672,8 @@ impl GitClient {
             .collect();
 
         // Get current PR labels
-        let current_pr_labels: HashSet<String> =
-            pr_info.labels.iter().map(|l| l.name.clone()).collect();
+        let current_pr_labels: HashSet<&str> =
+            pr_info.labels.iter().map(|l| l.name.as_str()).collect();
 
         let mut labels_to_create: Vec<String> = vec![];
         let mut label_ids = Vec::new();
@@ -682,7 +682,7 @@ impl GitClient {
             match existing_label_map.get(label.as_str()) {
                 Some(l) => {
                     // Only add the ID if the label isn't already on the PR
-                    if !current_pr_labels.contains(label) {
+                    if !current_pr_labels.contains(label.as_str()) {
                         label_ids.push(l.id.with_context(|| {
                             format!("failed to extract id from existing label '{}'", l.name)
                         })?);

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -902,7 +902,13 @@ pub fn validate_labels(labels: &[String]) -> anyhow::Result<()> {
             anyhow::bail!("Failed to add label `{l}`: it exceeds maximum length of 50 characters.");
         }
 
-        if l.trim().is_empty() {
+        if l.trim() != l {
+            anyhow::bail!(
+                "Failed to add label `{l}`: leading or trailing whitespace is not allowed."
+            );
+        }
+
+        if l.is_empty() {
             anyhow::bail!("Failed to add label. Empty labels are not allowed.");
         }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -652,7 +652,7 @@ impl GitClient {
         let mut unique_labels = HashSet::new();
         let labels: Vec<String> = labels
             .iter()
-            .filter(|&label| unique_labels.insert(label.clone()))
+            .filter(|&label| unique_labels.insert(label))
             .cloned()
             .collect();
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -563,18 +563,15 @@ impl GitClient {
         };
 
         info!("opened pr: {}", git_pr.html_url);
-        if !pr.labels.is_empty() {
-            self.add_labels(&pr.labels, git_pr.number)
-                .await
-                .context("Failed to add labels")?;
-        }
+        self.add_labels(&pr.labels, git_pr.number)
+            .await
+            .context("Failed to add labels")?;
         Ok(git_pr)
     }
 
     #[instrument(skip(self))]
     pub async fn add_labels(&self, labels: &Vec<String>, pr_number: u64) -> anyhow::Result<()> {
         if labels.is_empty() {
-            warn!("No labels provided for PR #{}", pr_number);
             return Ok(());
         }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -123,6 +123,8 @@ impl GitPr {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Label {
     pub name: String,
+    /// ID of the label.
+    /// Used by Gitea and GitHub. Not present in GitLab responses.
     id: Option<u64>,
 }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -663,7 +663,10 @@ impl GitClient {
 
         for label in labels {
             match label_map.get(&label) {
-                Some(id) => label_ids.push(id.context("failed to extract id")?.to_owned()),
+                Some(id) => label_ids.push(
+                    id.with_context(|| format!("failed to extract id from label {label}"))?
+                        .to_owned(),
+                ),
                 None => labels_to_create.push(label),
             }
         }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -580,7 +580,7 @@ impl GitClient {
             BackendType::Gitlab => self.post_gitlab_labels(labels, pr_number).await,
             BackendType::Gitea => {
                 let (labels_to_create, mut label_ids) = self
-                    .get_pr_info_and_categorize_labels(pr_number, labels.to_owned())
+                    .get_pr_info_and_categorize_labels(pr_number, labels)
                     .await?;
 
                 let new_label_ids = self.create_labels(&labels_to_create).await?;
@@ -645,7 +645,7 @@ impl GitClient {
     async fn get_pr_info_and_categorize_labels(
         &self,
         pr_number: u64,
-        labels: Vec<String>,
+        labels: &[String],
     ) -> anyhow::Result<(Vec<String>, Vec<u64>)> {
         let current_pr_info = self
             .get_pr_info(pr_number)
@@ -662,10 +662,10 @@ impl GitClient {
         let mut label_ids = Vec::new();
 
         for label in labels {
-            match label_map.get(&label) {
+            match label_map.get(label) {
                 Some(id) => label_ids
                     .push(id.with_context(|| format!("failed to extract id from label {label}"))?),
-                None => labels_to_create.push(label),
+                None => labels_to_create.push(label.to_owned()),
             }
         }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -212,7 +212,7 @@ pub struct GitLabMrEdit {
     state_event: Option<String>,
 }
 
-#[derive(Serialize, Default, Debug, Clone)]
+#[derive(Serialize, Default)]
 pub struct PrEdit {
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -570,14 +570,8 @@ impl GitClient {
             return Ok(());
         }
 
-        if let Some(label) = labels.iter().find(|l| l.len() > 50 || l.trim().is_empty()) {
-            let error_msg = if label.trim().is_empty() {
-                "Empty labels are not allowed"
-            } else {
-                "Label exceeds maximum length of 50 characters"
-            };
-            anyhow::bail!("Failed to add labels: {} - '{}'", error_msg, label);
-        }
+        validate_labels(labels)?;
+
         match self.backend {
             BackendType::Github => {
                 self.client
@@ -837,6 +831,19 @@ impl GitClient {
         };
         format!("{}/{commits_api_path}{commit}", self.repo_url())
     }
+}
+
+fn validate_labels(labels: &Vec<String>) -> anyhow::Result<()> {
+    for l in labels {
+        if l.len() > 50 {
+            anyhow::bail!("Failed to add label `{l}`. It exceeds maximum length of 50 characters.");
+        }
+
+        if l.trim().is_empty() {
+            anyhow::bail!("Failed to add label. Empty labels are not allowed.");
+        }
+    }
+    Ok(())
 }
 
 /// Representation of a single commit.

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -605,7 +605,10 @@ impl GitClient {
             }
             BackendType::Gitea => {
                 // uses label_id's not label_names hence need to fetch labels
-                let current_pr_info = self.get_pr_info(pr_number).await.context("failed to get pr info")?;
+                let current_pr_info = self
+                    .get_pr_info(pr_number)
+                    .await
+                    .context("failed to get pr info")?;
                 let existing_labels = current_pr_info.labels;
 
                 // for faster retrieving used a hash

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -576,8 +576,6 @@ impl GitClient {
             return Ok(());
         }
 
-        validate_labels(labels)?;
-
         match self.backend {
             BackendType::Github => {
                 self.client
@@ -856,7 +854,7 @@ impl GitClient {
     }
 }
 
-fn validate_labels(labels: &Vec<String>) -> anyhow::Result<()> {
+pub fn validate_labels(labels: &Vec<String>) -> anyhow::Result<()> {
     for l in labels {
         if l.len() > 50 {
             anyhow::bail!("Failed to add label `{l}`: it exceeds maximum length of 50 characters.");

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -663,10 +663,8 @@ impl GitClient {
 
         for label in labels {
             match label_map.get(&label) {
-                Some(id) => label_ids.push(
-                    id.with_context(|| format!("failed to extract id from label {label}"))?
-                        .to_owned(),
-                ),
+                Some(id) => label_ids
+                    .push(id.with_context(|| format!("failed to extract id from label {label}"))?),
                 None => labels_to_create.push(label),
             }
         }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -114,6 +114,10 @@ impl GitPr {
     pub fn branch(&self) -> &str {
         self.head.ref_field.as_str()
     }
+
+    pub fn label_names(&self) -> Vec<&str> {
+        self.labels.iter().map(|l| l.name.as_str()).collect()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -836,7 +836,7 @@ impl GitClient {
 fn validate_labels(labels: &Vec<String>) -> anyhow::Result<()> {
     for l in labels {
         if l.len() > 50 {
-            anyhow::bail!("Failed to add label `{l}`. It exceeds maximum length of 50 characters.");
+            anyhow::bail!("Failed to add label `{l}`: it exceeds maximum length of 50 characters.");
         }
 
         if l.trim().is_empty() {

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -699,23 +699,20 @@ impl GitClient {
                 }
                 StatusCode::NOT_FOUND => {
                     anyhow::bail!(
-                        "Failed to create label '{}'. \n\
+                        "Failed to create label '{label}'. \n\
                     Please check if the repository URL '{}' \
                     is correct and the user has the necessary permissions.",
-                        label,
                         self.repo_url()
                     );
                 }
                 StatusCode::UNPROCESSABLE_ENTITY => anyhow::bail!(
-                    "Label '{}' creation failed. Existing labels are {:?}",
-                    label,
+                    "Label '{label}' creation failed. Existing labels are {:?}",
                     labels_to_create
                 ),
                 _ => {
                     anyhow::bail!(
-                        "Label creation failed response is {} \n\
+                        "Label creation failed response is {label} \n\
                     With Status Code: {}",
-                        label,
                         res.status()
                     );
                 }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -676,7 +676,7 @@ impl GitClient {
         let mut label_ids = Vec::new();
 
         for label in labels_to_create {
-            debug!("Backend Gitea creating label: {}", label);
+            debug!("Backend Gitea creating label: {label}");
             let res = self
                 .client
                 .post(format!("{}/labels", self.repo_url()))

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -125,6 +125,7 @@ pub struct Label {
     pub name: String,
     id: u64,
 }
+
 impl From<GitLabMr> for GitPr {
     fn from(value: GitLabMr) -> Self {
         let body = if value.description.is_empty() {
@@ -170,10 +171,7 @@ pub struct GitLabAuthor {
 
 impl From<GitPr> for GitLabMr {
     fn from(value: GitPr) -> Self {
-        let mut desc = "".to_string();
-        if let Some(body) = value.body {
-            desc = body;
-        }
+        let desc = value.body.unwrap_or_default();
         GitLabMr {
             author: GitLabAuthor {
                 username: value.user.login,

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -13,7 +13,7 @@ use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
 #[derive(Debug, Clone)]
 pub enum GitBackend {

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -583,7 +583,7 @@ impl GitClient {
                     .get_pr_info_and_categorize_labels(pr_number, labels)
                     .await?;
 
-                let new_label_ids = self.create_labels(&labels_to_create).await?;
+                let new_label_ids = self.create_gitea_labels(&labels_to_create).await?;
                 label_ids.extend(new_label_ids);
 
                 anyhow::ensure!(
@@ -672,7 +672,7 @@ impl GitClient {
         Ok((labels_to_create, label_ids))
     }
 
-    async fn create_labels(&self, labels_to_create: &[String]) -> anyhow::Result<Vec<u64>> {
+    async fn create_gitea_labels(&self, labels_to_create: &[String]) -> anyhow::Result<Vec<u64>> {
         let mut label_ids = Vec::new();
 
         for label in labels_to_create {

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -570,7 +570,7 @@ impl GitClient {
     }
 
     #[instrument(skip(self))]
-    pub async fn add_labels(&self, labels: &Vec<String>, pr_number: u64) -> anyhow::Result<()> {
+    pub async fn add_labels(&self, labels: &[String], pr_number: u64) -> anyhow::Result<()> {
         if labels.is_empty() {
             return Ok(());
         }
@@ -662,7 +662,7 @@ impl GitClient {
         Ok((labels_to_create, label_ids))
     }
 
-    async fn create_labels(&self, labels_to_create: &Vec<String>) -> anyhow::Result<Vec<u64>> {
+    async fn create_labels(&self, labels_to_create: &[String]) -> anyhow::Result<Vec<u64>> {
         let mut label_ids = Vec::new();
 
         for label in labels_to_create {
@@ -853,7 +853,7 @@ impl GitClient {
     }
 }
 
-pub fn validate_labels(labels: &Vec<String>) -> anyhow::Result<()> {
+pub fn validate_labels(labels: &[String]) -> anyhow::Result<()> {
     for l in labels {
         if l.len() > 50 {
             anyhow::bail!("Failed to add label `{l}`: it exceeds maximum length of 50 characters.");

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -676,7 +676,7 @@ impl GitClient {
         let mut label_ids = Vec::new();
 
         for label in labels_to_create {
-            info!("Backend Gitea Creating label: {}", label);
+            debug!("Backend Gitea creating label: {}", label);
             let res = self
                 .client
                 .post(format!("{}/labels", self.repo_url()))
@@ -692,7 +692,10 @@ impl GitClient {
             match res.status() {
                 StatusCode::CREATED => {
                     let new_label: Label = res.json().await?;
-                    label_ids.push(new_label.id.context("failed to extract id")?);
+                    let label_id = new_label
+                        .id
+                        .with_context(|| format!("failed to extract id from label {label}"))?;
+                    label_ids.push(label_id);
                 }
                 StatusCode::NOT_FOUND => {
                     anyhow::bail!(

--- a/crates/release_plz_core/src/git/gitea_client.rs
+++ b/crates/release_plz_core/src/git/gitea_client.rs
@@ -61,9 +61,3 @@ struct Commit {
 struct EditPullRequest {
     state: &'static str,
 }
-
-#[derive(Deserialize, Debug)]
-pub struct GiteaLabelResponseStruct {
-    pub id: u64,
-    pub name: String,
-}

--- a/crates/release_plz_core/src/git/gitea_client.rs
+++ b/crates/release_plz_core/src/git/gitea_client.rs
@@ -66,5 +66,4 @@ struct EditPullRequest {
 pub struct GiteaLabelResponseStruct {
     pub id: u64,
     pub name: String,
-    pub color: String,
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -421,7 +421,6 @@ Before changing the release-plz branch you should close the old release PR.
 #### The `pr_labels` field
 
 Add labels to the Pull Request opened by release-plz.
-*(GitHub and GitLab only)*.
 
 Example:
 

--- a/website/docs/usage/release-pr.md
+++ b/website/docs/usage/release-pr.md
@@ -45,6 +45,7 @@ Gitea with the `--backend` option:
 `release-plz release-pr --git-token <gitea application token> --backend gitea`
 
 The token needs to have the following permissions:
+
 - `read:repository`, `write:repository`: to create the release PR.
 - `read:issue`, `write:issue`: to add labels to the release PR.
 

--- a/website/docs/usage/release-pr.md
+++ b/website/docs/usage/release-pr.md
@@ -44,6 +44,10 @@ Gitea with the `--backend` option:
 
 `release-plz release-pr --git-token <gitea application token> --backend gitea`
 
+The token needs to have the following permissions:
+- `read:repository`, `write:repository`: to create the release PR.
+- `read:issue`, `write:issue`: to add labels to the release PR.
+
 ## Github
 
 On Github, the `release-plz release-pr` will use your `--git-token` to create a commit

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -56,11 +56,14 @@ Then you can run `release-plz release` with the following arguments:
 
 `releases-plz` supports creating releases on Gitea with the `--backend gitea` option.
 
-TODO: document how to create a token on Gitea.
-
 Then you can run `release-plz release` in Gitea CI with the following arguments:
 
 `release-plz release --backend gitea --git-token <gitea_token>`
+
+The token needs to have the following permissions:
+- `read:repository`, `write:repository`: to create git tags and releases.
+
+TODO: document how to create a token on Gitea.
 
 ## Json output
 

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -61,6 +61,7 @@ Then you can run `release-plz release` in Gitea CI with the following arguments:
 `release-plz release --backend gitea --git-token <gitea_token>`
 
 The token needs to have the following permissions:
+
 - `read:repository`, `write:repository`: to create git tags and releases.
 
 TODO: document how to create a token on Gitea.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

### Add labels Gitea Enhancement.
Close [#1881](https://github.com/release-plz/release-plz/issues/1881)

1. Fixed Typo in Struct Name:

- Renamed the struct GiteaRelase to GiteaRelease to correct a spelling error.

2. Pull Request Labels Management:

- New Structs and Fields:
    - Introduced a Label struct with name and ID fields.
    - Added a labels field to existing structs like GitPr and GitLabMr to accommodate label information.

- Label Validation:
    - Implemented validation to ensure label names are non-empty and do not exceed 50 characters, providing appropriate error messages for invalid inputs.

- Gitea Integration:
    - Introduced a GiteaLabelResponseStruct to handle responses from Gitea's label API.
    - Enhanced label management for Gitea backends by:
        -   Fetching existing labels.
        -   Creating new labels if they don't exist.
        -   Mapping labels to their respective IDs.
        -   Assigning labels to PRs using these IDs.
        
3. Token Scope Enhancement:

    - Updated token creation to include read:issue and write:issue permissions, facilitating the new label management functionalities.
    
4.  Testing:
Added test cases to verify label functionalities:
release_plz_add_labels_to_release_pull_request: Assesses the addition of labels to a release PR.
release_plz_add_invalid_labels_to_release_pr: Evaluates the validation process for invalid labels.


