### PR TITLE
fix: don't suppress git error when determining commits to release

### DIFF
--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -645,7 +645,9 @@ impl Updater<'_> {
             .map(|&p| {
                 let diff = self
                     .get_diff(p, registry_packages, repository)
-                    .context("failed to retrieve difference between packages")?;
+                    .with_context(|| {
+                        format!("failed to retrieve difference of package {}", p.name)
+                    })?;
                 Ok((p, diff))
             })
             .collect();


### PR DESCRIPTION
the git error from call to `checkout_last_commit_at_paths` shouldn't be silenced. Fix : #1960
If the git repository files are corrupted, we need to have an error.

I have tried to reproduce a case where we can have an error from `checkout_last_commit_at_paths` because of no commit to include in diff, but without success, to get the `there are no commits` as valid message.
