### PR TITLE
whitelist .git folder for copying local repo.

### DIFF
--- a/crates/release_plz_core/src/copy_dir.rs
+++ b/crates/release_plz_core/src/copy_dir.rs
@@ -48,7 +48,13 @@ pub fn copy_dir(from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> anyhow:
 #[tracing::instrument]
 #[expect(clippy::filetype_is_file)] // we want to distinguish between files and symlinks
 fn copy_directory(from: &Utf8Path, to: Utf8PathBuf) -> Result<(), anyhow::Error> {
+    // Create a override to whitelist .git folder
+    // to copy it without take care of .gitignore content
+    let git_folder_override = ignore::overrides::OverrideBuilder::new(from)
+        .add(".git/**")?
+        .build()?;
     let walker = ignore::WalkBuilder::new(from)
+        .overrides(git_folder_override)
         // Read hidden files
         .hidden(false)
         // Don't consider `.ignore` files.


### PR DESCRIPTION
This should fix issue #1961
The `.gitignore` rules shouldn't apply for .git directory. Otherwise, we can have a broken git repository,
for example if `*.idx` is present in ignore list.