### PR TITLE
fix(core): Use dunce to canonicalize package paths

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 disallowed-methods = [
-    { path = "cargo_metadata::camino::Utf8Path::canonicalize_utf8", reason = "use `canonicalize_utf8` instead" },
-    { path = "camino::Utf8Path::canonicalize_utf8", reason = "use `canonicalize_utf8` instead" },
+    { path = "cargo_metadata::camino::Utf8Path::canonicalize_utf8", reason = "use `fs_utils::canonicalize_utf8` instead" },
+    { path = "camino::Utf8Path::canonicalize_utf8", reason = "use `fs_utils::canonicalize_utf8` instead" },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    { path = "cargo_metadata::camino::Utf8Path::canonicalize_utf8", reason = "use `canonicalize_utf8` instead" },
+    { path = "camino::Utf8Path::canonicalize_utf8", reason = "use `canonicalize_utf8` instead" },
+]

--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -1,5 +1,5 @@
-use crate::root_repo_path_from_manifest_dir;
 use crate::semver_check::SemverCheck;
+use crate::{fs_utils, root_repo_path_from_manifest_dir};
 use crate::{tmp_repo::TempRepo, PackagePath, UpdateRequest, UpdateResult};
 use anyhow::Context;
 use cargo_metadata::camino::Utf8Path;
@@ -302,7 +302,7 @@ pub fn set_version(
         .write()
         .with_context(|| format!("cannot update manifest {:?}", &local_manifest.path))?;
 
-    let package_path = Utf8Path::canonicalize_utf8(crate::manifest_dir(&local_manifest.path)?)?;
+    let package_path = fs_utils::canonicalize_utf8(crate::manifest_dir(&local_manifest.path)?)?;
     update_dependencies(all_packages, version, &package_path, workspace_manifest)?;
     Ok(())
 }

--- a/crates/release_plz_core/src/fs_utils.rs
+++ b/crates/release_plz_core/src/fs_utils.rs
@@ -17,6 +17,12 @@ pub fn current_directory() -> anyhow::Result<Utf8PathBuf> {
     to_utf8_pathbuf(std::env::current_dir().context("Unable to get current directory.")?)
 }
 
+pub fn canonicalize_utf8(path: &Utf8Path) -> anyhow::Result<Utf8PathBuf> {
+    let canonicalized =
+        dunce::canonicalize(path).with_context(|| format!("cannot canonicalize path {path:?}"))?;
+    to_utf8_pathbuf(canonicalized)
+}
+
 #[derive(Debug)]
 pub struct Utf8TempDir {
     // temporary directory that will be deleted in the `Drop` method

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -1,5 +1,4 @@
 use crate::diff::Commit;
-use crate::{fs_utils, get_cargo_package_files};
 use crate::{
     changelog_filler::{fill_commit, get_required_info},
     changelog_parser::{self, ChangelogRelease},
@@ -17,6 +16,7 @@ use crate::{
     version::NextVersionFromDiff,
     ChangelogBuilder, PackagesToUpdate, PackagesUpdate, Project, Remote, CHANGELOG_FILENAME,
 };
+use crate::{fs_utils, get_cargo_package_files};
 use crate::{GitBackend, GitClient};
 use anyhow::Context;
 use cargo::util::VersionExt;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -1,5 +1,5 @@
 use crate::diff::Commit;
-use crate::get_cargo_package_files;
+use crate::{fs_utils, get_cargo_package_files};
 use crate::{
     changelog_filler::{fill_commit, get_required_info},
     changelog_parser::{self, ChangelogRelease},
@@ -36,7 +36,6 @@ use regex::Regex;
 use std::path::PathBuf;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    io,
     path::Path,
 };
 use toml_edit::TableLike;
@@ -280,8 +279,8 @@ impl UpdateRequest {
         }
     }
 
-    pub fn with_registry_manifest_path(self, registry_manifest: &Utf8Path) -> io::Result<Self> {
-        let registry_manifest = Utf8Path::canonicalize_utf8(registry_manifest)?;
+    pub fn with_registry_manifest_path(self, registry_manifest: &Utf8Path) -> anyhow::Result<Self> {
+        let registry_manifest = fs_utils::canonicalize_utf8(registry_manifest)?;
         Ok(Self {
             registry_manifest: Some(registry_manifest),
             ..self

--- a/crates/release_plz_core/src/package_path.rs
+++ b/crates/release_plz_core/src/package_path.rs
@@ -8,7 +8,7 @@ pub trait PackagePath {
     fn package_path(&self) -> anyhow::Result<&Utf8Path>;
 
     fn canonical_path(&self) -> anyhow::Result<Utf8PathBuf> {
-        let p = Utf8Path::canonicalize_utf8(self.package_path()?)?;
+        let p = dunce::canonicalize(self.package_path()?)?.try_into()?;
         Ok(p)
     }
 }

--- a/crates/release_plz_core/src/package_path.rs
+++ b/crates/release_plz_core/src/package_path.rs
@@ -4,11 +4,13 @@ use cargo_metadata::{
     Package,
 };
 
+use crate::fs_utils;
+
 pub trait PackagePath {
     fn package_path(&self) -> anyhow::Result<&Utf8Path>;
 
     fn canonical_path(&self) -> anyhow::Result<Utf8PathBuf> {
-        let p = dunce::canonicalize(self.package_path()?)?.try_into()?;
+        let p = fs_utils::canonicalize_utf8(self.package_path()?)?;
         Ok(p)
     }
 }

--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -9,9 +9,11 @@ use cargo_utils::CARGO_TOML;
 use tracing::debug;
 
 use crate::{
-    copy_to_temp_dir, fs_utils::strip_prefix, manifest_dir, new_manifest_dir_path,
-    root_repo_path_from_manifest_dir, tmp_repo::TempRepo, workspace_packages, Publishable as _,
-    ReleaseMetadata, ReleaseMetadataBuilder,
+    copy_to_temp_dir,
+    fs_utils::{self, strip_prefix},
+    manifest_dir, new_manifest_dir_path, root_repo_path_from_manifest_dir,
+    tmp_repo::TempRepo,
+    workspace_packages, Publishable as _, ReleaseMetadata, ReleaseMetadataBuilder,
 };
 use crate::{
     tera::{tera_context, tera_var, PACKAGE_VAR, VERSION_VAR},
@@ -279,13 +281,8 @@ fn override_packages_path(
     metadata: &Metadata,
     manifest_dir: &Utf8Path,
 ) -> Result<(), anyhow::Error> {
-    let canonicalized_workspace_root =
-        dunce::canonicalize(&metadata.workspace_root).with_context(|| {
-            format!(
-                "failed to canonicalize workspace root {:?}",
-                metadata.workspace_root
-            )
-        })?;
+    let canonicalized_workspace_root = fs_utils::canonicalize_utf8(&metadata.workspace_root)
+        .context("failed to canonicalize workspace root")?;
     for p in packages {
         let old_path = p.package_path()?;
         let relative_package_path =


### PR DESCRIPTION
The previous implementation of `PackagePath::canonicalize` was not using `dunce::canonicalize`. This lead to Package::dependencies_to_update comparing a dunce canonicalized path to a std::fs canonicalized path.

On Windows, the former would rarely add the extended length prefix, but the latter always added the extended path length prefix. This led to `next_ver::is_dependency_referred_to_package` always returning false on Windows, causing versioned path dependencies not being updated.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
