### PR TITLE
fix: Make release-pr tests Use UTC rather than local timezone

### DIFF
--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1,6 +1,5 @@
 use crate::helpers::test_context::TestContext;
 use cargo_utils::LocalManifest;
-use chrono::Local;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
@@ -332,5 +331,5 @@ fn move_readme(context: &TestContext, message: &str) {
 }
 
 fn today() -> String {
-    Local::now().format("%Y-%m-%d").to_string()
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
 }

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -331,5 +331,6 @@ fn move_readme(context: &TestContext, message: &str) {
 }
 
 fn today() -> String {
+    // The changelogs specify the release date in UTC.
     chrono::Utc::now().format("%Y-%m-%d").to_string()
 }


### PR DESCRIPTION
The `release-pr` tests check the contents of the opened PR, which are generated from the changelogs. The changelogs specify the release date in UTC:

https://github.com/release-plz/release-plz/blob/c633007e752ba3d127af03e4c18b4fa5b7fdf1fc/crates/release_plz_core/src/changelog.rs#L321-L327

However, the release-pr test compares this UTC date to a date obtained from the local timezone. If the local timezone is not UTC and is at a different date than UTC, then this can cause issues. 