### PR TITLE
fix(core): Stash uncommited changes in dirty repos during update

### DIFF
--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -423,7 +423,9 @@ pub async fn next_versions(input: &UpdateRequest) -> anyhow::Result<(PackagesUpd
     if !input.allow_dirty {
         repo_is_clean_result?;
     } else if repo_is_clean_result.is_err() {
-        // Stash uncommitted changes so we can freely check out other commits
+        // Stash uncommitted changes so we can freely check out other commits.
+        // This function is ran inside a temporary repository, so this has no
+        // effects on the original repository of the user.
         repository.repo.git(&[
             "stash",
             "push",


### PR DESCRIPTION
When obtaining the next versions of the workspace, if `allow_dirty` is set to true and the repository is dirty, we commit the uncommitted changes so that they can easily be restored without being lost with a `checkout_head` (which happens a couple times during the diff process).

Note that this commit is only made in the `TempRepo` made by `Project::get_repo`, and the user's original repo remains untouched.

As per the recommendation in https://github.com/release-plz/release-plz/pull/1982#issuecomment-2601007848, this was changed to _stash_ the uncommitted changes rather than commit them.