### PR TITLE
fix(core): Make `release --dry-run` more informative

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -727,7 +727,7 @@ async fn release_package(
     let should_create_git_relase = input.is_git_release_enabled(&release_info.package.name);
 
     if should_publish {
-        // Run `cargo publish --dry-run`
+        // Run `cargo publish --dry-run` if `input.dry_run` is true.
         let output = run_cargo_publish(release_info.package, input, workspace_root)
             .context("failed to run cargo publish")?;
         if !output.status.success()

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -812,23 +812,24 @@ fn log_dry_run_info(
         release_info.package.name, release_info.package.version
     );
 
+    let mut items_to_skip = vec![];
+
     if should_publish {
-        info!("{prefix} aborting registry upload due to dry run");
+        items_to_skip.push("cargo registry upload".to_string());
     }
 
     if should_create_git_tag {
-        info!(
-            "{prefix} skipping creation of git tag '{}' due to dry run",
-            release_info.git_tag
-        );
+        items_to_skip.push(format!("creation of tag '{}'", release_info.git_tag));
     }
 
     if should_create_git_release {
-        info!("{prefix} skipping git release creation due to dry run");
+        items_to_skip.push("creation of git release".to_string());
     }
 
-    if !should_publish && !should_create_git_tag && !should_create_git_release {
+    if items_to_skip.is_empty() {
         info!("{prefix} no release method enabled");
+    } else {
+        info!("{prefix} due to dry, skipping the following: {items_to_skip:?}",);
     }
 }
 

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -727,7 +727,7 @@ async fn release_package(
     let should_create_git_relase = input.is_git_release_enabled(&release_info.package.name);
 
     if should_publish {
-        // Run `cargo publish --dry-run` if `input.dry_run` is true.
+        // Run `cargo publish`. Note that `--dry-run` is added if `input.dry_run` is true.
         let output = run_cargo_publish(release_info.package, input, workspace_root)
             .context("failed to run cargo publish")?;
         if !output.status.success()

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -813,7 +813,7 @@ fn log_dry_run_info(
     );
 
     if should_publish {
-        info!("{prefix} aborting registry upload due to dry run",);
+        info!("{prefix} aborting registry upload due to dry run");
     }
 
     if should_create_git_tag {
@@ -824,11 +824,11 @@ fn log_dry_run_info(
     }
 
     if should_create_git_release {
-        info!("{prefix} skipping git release creation due to dry run",);
+        info!("{prefix} skipping git release creation due to dry run");
     }
 
     if !should_publish && !should_create_git_tag && !should_create_git_release {
-        info!("{prefix} no release method enabled",);
+        info!("{prefix} no release method enabled");
     }
 }
 

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -727,7 +727,7 @@ async fn release_package(
     let should_create_git_relase = input.is_git_release_enabled(&release_info.package.name);
 
     if should_publish {
-        // Runs `cargo publish --dry-run` in dry-run mode, so we can run this here
+        // Run `cargo publish --dry-run`
         let output = run_cargo_publish(release_info.package, input, workspace_root)
             .context("failed to run cargo publish")?;
         if !output.status.success()


### PR DESCRIPTION
When `--dry-run` is specified, prints (by adding `tracing` events) the steps that `release` would have taken, such as git tag and release creation.