### PR TITLE
feat: Release unpublishable packages

### DIFF
--- a/crates/release_plz/tests/all/release.rs
+++ b/crates/release_plz/tests/all/release.rs
@@ -1,3 +1,4 @@
+use cargo_utils::LocalManifest;
 use release_plz_core::fs_utils::Utf8TempDir;
 
 use crate::helpers::test_context::TestContext;
@@ -118,7 +119,7 @@ async fn release_plz_does_not_release_a_new_project_if_release_always_is_false()
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_releases_a_new_project_with_custom_release() {
+async fn release_plz_releases_a_new_project_with_custom_release_and_manifest_publish_false() {
     let context = TestContext::new().await;
 
     let config = r#"
@@ -127,6 +128,12 @@ async fn release_plz_releases_a_new_project_with_custom_release() {
     git_release_body = "Welcome to this new release!\n{{ changelog }}"
     "#;
     context.write_release_plz_toml(config);
+
+    // Test publish = true in release-plz config but publish = false in manifest
+    let cargo_toml_path = context.repo_dir().join("Cargo.toml");
+    let mut cargo_toml = LocalManifest::try_new(&cargo_toml_path).unwrap();
+    cargo_toml.data["package"]["publish"] = false.into();
+    cargo_toml.write().unwrap();
 
     let crate_name = &context.gitea.repo;
 

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -578,9 +578,12 @@ async fn release_package_if_needed(
     };
     for CargoRegistry { name, mut index } in registry_indexes {
         let token = input.find_registry_token(name.as_deref())?;
-        if is_published(&mut index, package, input.publish_timeout, &token)
-            .await
-            .context("can't determine if package is published")?
+        // Only check if this package has already been published to the registry if
+        // registry publishing is enabled for it
+        if input.is_publish_enabled(&release_info.package.name)
+            && is_published(&mut index, package, input.publish_timeout, &token)
+                .await
+                .context("can't determine if package is published")?
         {
             info!("{} {}: already published", package.name, package.version);
             continue;

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -531,7 +531,7 @@ async fn release_packages(
     repo: &Repo,
     git_client: &GitClient,
 ) -> anyhow::Result<Option<Release>> {
-    let packages = project.publishable_packages();
+    let packages = project.workspace_packages();
     let release_order = release_order(&packages).context("cannot determine release order")?;
     let mut package_releases: Vec<PackageRelease> = vec![];
     for package in release_order {

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -76,6 +76,11 @@ impl ReleaseRequest {
         cargo_utils::workspace_manifest(&self.metadata)
     }
 
+    /// The [`Metadata`] of the workspace or package to be released.
+    pub fn cargo_metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
     pub fn with_registry(mut self, registry: impl Into<String>) -> Self {
         self.registry = Some(registry.into());
         self

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -1,4 +1,3 @@
-use cargo_metadata::camino::Utf8Path;
 use cargo_utils::CARGO_TOML;
 use git_cmd::Repo;
 
@@ -13,8 +12,8 @@ use crate::git::backend::{
 use crate::git::github_graphql;
 use crate::pr::{Pr, DEFAULT_BRANCH_PREFIX, OLD_BRANCH_PREFIX};
 use crate::{
-    copy_to_temp_dir, new_manifest_dir_path, new_project_root, publishable_packages_from_manifest,
-    root_repo_path_from_manifest_dir, update, PackagesUpdate, UpdateRequest,
+    copy_to_temp_dir, new_manifest_dir_path, new_project_root, root_repo_path_from_manifest_dir,
+    update, PackagesUpdate, Project, UpdateRequest,
 };
 
 #[derive(Debug)]
@@ -123,8 +122,9 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
         let repo = Repo::new(tmp_project_root)?;
         let there_are_commits_to_push = repo.is_clean().is_err();
         if there_are_commits_to_push {
+            let local_project = input.update_request.create_project()?;
             let pr = open_or_update_release_pr(
-                &local_manifest,
+                &local_project,
                 &packages_to_update,
                 &git_client,
                 &repo,
@@ -153,7 +153,7 @@ struct ReleasePrOptions {
 }
 
 async fn open_or_update_release_pr(
-    local_manifest: &Utf8Path,
+    project: &Project,
     packages_to_update: &PackagesUpdate,
     git_client: &GitClient,
     repo: &Repo,
@@ -184,8 +184,7 @@ async fn open_or_update_release_pr(
     }
 
     let new_pr = {
-        let project_contains_multiple_pub_packages =
-            publishable_packages_from_manifest(local_manifest)?.len() > 1;
+        let project_contains_multiple_pub_packages = project.workspace_packages().len() > 1;
         Pr::new(
             repo.original_branch(),
             packages_to_update,

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -379,6 +379,16 @@ impl UpdateRequest {
     pub fn repo_url(&self) -> Option<&RepoUrl> {
         self.repo_url.as_ref()
     }
+
+    pub(crate) fn create_project(&self) -> anyhow::Result<Project> {
+        Project::new(
+            &self.local_manifest,
+            self.single_package.as_deref(),
+            &self.packages_config.overrides.keys().cloned().collect(),
+            &self.metadata,
+            self,
+        )
+    }
 }
 
 impl ReleaseMetadataBuilder for UpdateRequest {
@@ -394,14 +404,7 @@ impl ReleaseMetadataBuilder for UpdateRequest {
 /// Determine next version of packages
 #[instrument(skip_all)]
 pub async fn next_versions(input: &UpdateRequest) -> anyhow::Result<(PackagesUpdate, TempRepo)> {
-    let overrides = input.packages_config.overrides.keys().cloned().collect();
-    let local_project = Project::new(
-        &input.local_manifest,
-        input.single_package.as_deref(),
-        &overrides,
-        &input.metadata,
-        input,
-    )?;
+    let local_project = input.create_project()?;
     let updater = Updater {
         project: &local_project,
         req: input,
@@ -411,7 +414,7 @@ pub async fn next_versions(input: &UpdateRequest) -> anyhow::Result<(PackagesUpd
     // to determine the new commits.
     let registry_packages = registry_packages::get_registry_packages(
         input.registry_manifest.as_deref(),
-        &local_project.publishable_packages(),
+        &local_project.workspace_packages(),
         input.registry.as_deref(),
     )?;
 
@@ -627,7 +630,7 @@ impl Updater<'_> {
         // package at a time.
         let packages_diffs_res: anyhow::Result<Vec<(&Package, Diff)>> = self
             .project
-            .publishable_packages()
+            .workspace_packages()
             .iter()
             .map(|&p| {
                 let diff = self

--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -96,6 +96,7 @@ impl Project {
         &self.root
     }
 
+    /// Get all the packages that should be published to a Cargo registry.
     pub fn publishable_packages(&self) -> Vec<&Package> {
         self.packages
             .iter()
@@ -103,7 +104,7 @@ impl Project {
             .collect()
     }
 
-    /// Get all packages, including non-publishable.
+    /// Get all packages that should be processed by release-plz, including non-publishable.
     pub fn workspace_packages(&self) -> Vec<&Package> {
         self.packages.iter().collect()
     }


### PR DESCRIPTION
`release-plz` currently does not process packages with `package.publish = false` in their Cargo.toml (i.e. unpublishable packages) at all. This PR allows such packages to be processed and released (to places other than Cargo registries) by release-plz.

However, to avoid [breaking workflows](https://github.com/release-plz/release-plz/pull/1872#issuecomment-2577202196) for existing workspaces with unpublishable packages, this PR also introduces a config change to only enable processing of nonpunishable packages if it is explicitly enabled in the release-plz config. In other words, the processing of unpublishable packages must be made opt-in.

This is done by setting `release = true` in the package-specific config for an unpublishable package, _even if_ `release = true` is set for the workspace. In the future, we could [consider adding an option](https://github.com/release-plz/release-plz/pull/1872#issuecomment-2582031148) like `release_unpublishable` to the `[workspace]` config to opt into releasing _all_ unpublishable packages in the workspace.

## TODO
- [ ] Update website documentation to reflect new behavior