### PR TITLE
feat: Download packages from different registries in parallel to improve performance

### DIFF
--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -105,6 +105,7 @@ fn download_packages_from_registry(
         })
     });
 
+    // Clone from different registries in parallel
     std::thread::scope(|scope| {
         let mut registry_packages: Vec<Package> = vec![];
         let mut handles = Vec::new();

--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -105,7 +105,7 @@ fn download_packages_from_registry(
         })
     });
 
-    // Clone from different registries in parallel
+    // Clone from the different registries in parallel
     std::thread::scope(|scope| {
         let mut registry_packages: Vec<Package> = vec![];
         let mut handles = Vec::new();


### PR DESCRIPTION
Primarily looking at Pavex here, where downloading packages takes several seconds.