### PR TITLE
fix: support env var override for registry index

### DIFF
--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -42,7 +42,7 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> anyhow::Res
 
     // set top-level env var override if it exists.
     if let Some(registry_name) = registry {
-        if let Some(env_var_override) = registry.and_then(registry_index_url_from_env) {
+        if let Some(env_var_override) = registry_index_url_from_env(registry_name) {
             registries
                 .entry(registry_name.to_string())
                 .or_insert(Source {

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -1057,20 +1057,13 @@ mod tests {
         let token = "t0p$eCrEt";
         let token_env_var = format!("CARGO_REGISTRIES_{}_TOKEN", registry_name.to_uppercase());
 
-        let old_value = env::var(&token_env_var);
-        env::set_var(&token_env_var, token);
+        with_env_var(&token_env_var, token, || {
+            let request = ReleaseRequest::new(fake_metadata()).with_registry(registry_name);
+            let registry_token = request.find_registry_token(Some(registry_name)).unwrap();
 
-        let request = ReleaseRequest::new(fake_metadata()).with_registry(registry_name);
-        let registry_token = request.find_registry_token(Some(registry_name)).unwrap();
-
-        if let Ok(old) = old_value {
-            env::set_var(&token_env_var, old);
-        } else {
-            env::remove_var(&token_env_var);
-        }
-
-        assert!(registry_token.is_some());
-        assert_eq!(token, registry_token.unwrap().expose_secret());
+            assert!(registry_token.is_some());
+            assert_eq!(token, registry_token.unwrap().expose_secret());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Attempts to loop up a `CARGO_REGISTRIES_<name>_INDEX` env var as the highest priority override for registry indexes falling back to the cargo config hierarchy if not present.

## Related Issues
closes #2032 

## Todo
- [x] Test coverage
