### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.118](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.117...release-plz-v0.3.118) - 2025-02-08
+
+### Fixed
+
+- correctly detect if package is executable (#2041)
+
 ## [0.3.117](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.116...release-plz-v0.3.117) - 2025-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "release-plz"
-version = "0.3.117"
+version = "0.3.118"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "release_plz_core"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-plz"
-version = "0.3.117"
+version = "0.3.118"
 edition.workspace = true
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/release-plz/release-plz"
@@ -21,7 +21,7 @@ all-static = ["release_plz_core/all-static"]
 
 [dependencies]
 git_cmd = { path = "../git_cmd", version = "0.6.20" }
-release_plz_core = { path = "../release_plz_core", version = "0.32.2", default-features = false }
+release_plz_core = { path = "../release_plz_core", version = "0.32.3", default-features = false }
 cargo_utils = { path = "../cargo_utils", version = "0.1" }
 
 anyhow.workspace = true

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.3](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.2...release_plz_core-v0.32.3) - 2025-02-08
+
+### Fixed
+
+- correctly detect if package is executable (#2041)
+
 ## [0.32.2](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.1...release_plz_core-v0.32.2) - 2025-02-08
 
 ### Added

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release_plz_core"
-version = "0.32.2"
+version = "0.32.3"
 edition.workspace = true
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/release-plz/release-plz/tree/main/crates/release_plz_core"


### PR DESCRIPTION



## 🤖 New release

* `release-plz`: 0.3.118
* `release_plz_core`: 0.32.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `release-plz`

<blockquote>

## [0.3.118](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.117...release-plz-v0.3.118) - 2025-02-08

### Fixed

- correctly detect if package is executable (#2041)
</blockquote>

## `release_plz_core`

<blockquote>

## [0.32.3](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.2...release_plz_core-v0.32.3) - 2025-02-08

### Fixed

- correctly detect if package is executable (#2041)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).