### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bring back breaking change description in pr body (#2055)
-- show previous version in PR body (#2054)
+- Show previous version in PR body (#2054)
 - Check semver breaking changes on packages containing both library and binary (#2053)
+- Show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
 
 ### Other
 
-- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
 - hint to install cargo semver checks to run tests (#2056)
 - remove duration-str dependency (#2047)
 - remove direct dipendency on lazy_static (#2049)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.120](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.119...release-plz-v0.3.120) - 2025-02-09
+
+### Fixed
+
+- Bring back breaking change description in pr body (#2055)
+- show previous version in PR body (#2054)
+- Check semver breaking changes on packages containing both library and binary (#2053)
+
+### Other
+
+- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
+- hint to install cargo semver checks to run tests (#2056)
+- remove duration-str dependency (#2047)
+- remove direct dipendency on lazy_static (#2049)
+
 ## [0.3.119](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.118...release-plz-v0.3.119) - 2025-02-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.78+curl-8.11.0"
+version = "0.4.79+curl-8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eec768341c5c7789611ae51cf6c459099f22e64a5d5d0ce4892434e33821eaf"
+checksum = "18a9bbeeb3996717ef1248018db20d1b0b5ba7165bff60e3b5135b4f4c2b37a5"
 dependencies = [
  "cc",
  "libc",
@@ -4422,7 +4422,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "release-plz"
-version = "0.3.119"
+version = "0.3.120"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "release_plz_core"
-version = "0.32.4"
+version = "0.32.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5349,7 +5349,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test_logs"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "tracing",
  "tracing-log",

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-plz"
-version = "0.3.119"
+version = "0.3.120"
 edition.workspace = true
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/release-plz/release-plz"
@@ -21,7 +21,7 @@ all-static = ["release_plz_core/all-static"]
 
 [dependencies]
 git_cmd = { path = "../git_cmd", version = "0.6.20" }
-release_plz_core = { path = "../release_plz_core", version = "0.32.4", default-features = false }
+release_plz_core = { path = "../release_plz_core", version = "0.32.5", default-features = false }
 cargo_utils = { path = "../cargo_utils", version = "0.1" }
 
 anyhow.workspace = true

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bring back breaking change description in pr body (#2055)
-- show previous version in PR body (#2054)
+- Show previous version in PR body (#2054)
 - Check semver breaking changes on packages containing both library and binary (#2053)
+- Show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
 
 ### Other
 
-- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
 - hint to install cargo semver checks to run tests (#2056)
 - remove direct dipendency on lazy_static (#2049)
 

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.5](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.4...release_plz_core-v0.32.5) - 2025-02-09
+
+### Fixed
+
+- Bring back breaking change description in pr body (#2055)
+- show previous version in PR body (#2054)
+- Check semver breaking changes on packages containing both library and binary (#2053)
+
+### Other
+
+- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
+- hint to install cargo semver checks to run tests (#2056)
+- remove direct dipendency on lazy_static (#2049)
+
 ## [0.32.4](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.3...release_plz_core-v0.32.4) - 2025-02-09
 
 ### Fixed

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release_plz_core"
-version = "0.32.4"
+version = "0.32.5"
 edition.workspace = true
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/release-plz/release-plz/tree/main/crates/release_plz_core"

--- a/crates/test_logs/CHANGELOG.md
+++ b/crates/test_logs/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/release-plz/release-plz/compare/test_logs-v0.1.30...test_logs-v0.1.31) - 2025-02-09
+
+### Other
+
+- remove direct dependency on once_cell (#2050)
+
 ## [0.1.30](https://github.com/release-plz/release-plz/compare/test_logs-v0.1.29...test_logs-v0.1.30) - 2024-12-07
 
 ### Other

--- a/crates/test_logs/Cargo.toml
+++ b/crates/test_logs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_logs"
-version = "0.1.30"
+version = "0.1.31"
 edition.workspace = true
 description = "Library to see logs in tests"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `test_logs`: 0.1.30 -> 0.1.31 (✓ API compatible changes)
* `release-plz`: 0.3.119 -> 0.3.120
* `release_plz_core`: 0.32.4 -> 0.32.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `test_logs`

<blockquote>

## [0.1.31](https://github.com/release-plz/release-plz/compare/test_logs-v0.1.30...test_logs-v0.1.31) - 2025-02-09

### Other

- remove direct dependency on once_cell (#2050)
</blockquote>

## `release-plz`

<blockquote>

## [0.3.120](https://github.com/release-plz/release-plz/compare/release-plz-v0.3.119...release-plz-v0.3.120) - 2025-02-09

### Fixed

- Bring back breaking change description in pr body (#2055)
- show previous version in PR body (#2054)
- Check semver breaking changes on packages containing both library and binary (#2053)

### Other

- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
- hint to install cargo semver checks to run tests (#2056)
- remove duration-str dependency (#2047)
- remove direct dipendency on lazy_static (#2049)
</blockquote>

## `release_plz_core`

<blockquote>

## [0.32.5](https://github.com/release-plz/release-plz/compare/release_plz_core-v0.32.4...release_plz_core-v0.32.5) - 2025-02-09

### Fixed

- Bring back breaking change description in pr body (#2055)
- show previous version in PR body (#2054)
- Check semver breaking changes on packages containing both library and binary (#2053)

### Other

- Fix show in pr body when semver check passed ([#2057](https://github.com/release-plz/release-plz/pull/2057))
- hint to install cargo semver checks to run tests (#2056)
- remove direct dipendency on lazy_static (#2049)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).