### PR TITLE
feat: Remove early exit on tag existence

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -723,7 +723,7 @@ async fn release_package(
 
     let should_publish = input.is_publish_enabled(&release_info.package.name);
     let should_create_git_tag = input.is_git_tag_enabled(&release_info.package.name);
-    let should_create_git_relase = input.is_git_release_enabled(&release_info.package.name);
+    let should_create_git_release = input.is_git_release_enabled(&release_info.package.name);
 
     if should_publish {
         // Run `cargo publish`. Note that `--dry-run` is added if `input.dry_run` is true.
@@ -746,7 +746,7 @@ async fn release_package(
             release_info,
             should_publish,
             should_create_git_tag,
-            should_create_git_relase,
+            should_create_git_release,
         );
         Ok(false)
     } else {
@@ -773,7 +773,7 @@ async fn release_package(
             link: "".to_string(),
             contributors,
         };
-        if should_create_git_relase {
+        if should_create_git_release {
             let release_body =
                 release_body(input, release_info.package, release_info.changelog, &remote);
             let release_config = input

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -561,7 +561,6 @@ async fn release_package_if_needed(
             "{} {}: Already published - Tag {} already exists",
             package.name, package.version, &git_tag
         );
-        return Ok(None);
     }
 
     let registry_indexes = registry_indexes(package, input.registry.clone())

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -794,7 +794,11 @@ async fn release_package(
                 latest: release_config.latest,
                 pre_release: is_pre_release,
             };
-            git_client.create_release(&git_release_info).await?;
+
+            let release_exists = git_client.release_exists(&git_release_info).await?;
+            if !release_exists {
+                git_client.create_release(&git_release_info).await?;
+            }
         }
 
         info!(


### PR DESCRIPTION
## Summary
Removes an early exit in the release subcommand allowing backfilling of packages if a git release exists.

## Related Issues
closes #2063 

## Todo
- [x] Manual tests
- [ ] Make tag creation idempotent in the release job.
