### PR TITLE
chore: simplify logging setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,16 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-verbosity-flag"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
-dependencies = [
- "clap",
- "tracing-core",
-]
-
-[[package]]
 name = "clap_builder"
 version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,7 +4022,6 @@ dependencies = [
  "cargo_utils",
  "chrono",
  "clap",
- "clap-verbosity-flag",
  "clap_complete",
  "dirs 6.0.0",
  "expect-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
+dependencies = [
+ "clap",
+ "tracing-core",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4431,6 +4441,7 @@ dependencies = [
  "cargo_utils",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "clap_complete",
  "dirs 6.0.0",
  "expect-test",
@@ -4453,7 +4464,6 @@ dependencies = [
  "toml",
  "toml_edit",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ cargo = { version = "0.86.0", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.23"
 clap_complete = "4.5.38"
-clap-verbosity-flag = { version = "3.0.2", default-features = false, features = ["tracing"] }
 crates-index = { version = "3.3.0", features = ["git", "sparse", "git-https"] }
 dirs = "6.0.0"
 dunce = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cargo = { version = "0.85.0", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.23"
 clap_complete = "4.5.38"
+clap-verbosity-flag = { version = "3.0.2", default-features = false, features = ["tracing"] }
 crates-index = { version = "3.3.0", features = ["git", "sparse", "git-https"] }
 dirs = "6.0.0"
 dunce = "1.0.5"

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -30,6 +30,7 @@ cargo_metadata.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete.workspace = true
+clap-verbosity-flag.workspace = true
 dirs.workspace = true
 fs-err.workspace = true
 git-cliff-core.workspace = true
@@ -41,7 +42,6 @@ serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tracing-log.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
 url.workspace = true

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -30,7 +30,6 @@ cargo_metadata.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete.workspace = true
-clap-verbosity-flag.workspace = true
 dirs.workspace = true
 fs-err.workspace = true
 git-cliff-core.workspace = true

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -17,11 +17,10 @@ use clap::{
     ValueEnum,
     builder::{Styles, styling::AnsiColor},
 };
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 use init::Init;
 use release_plz_core::fs_utils::current_directory;
 use set_version::SetVersion;
-use tracing::info;
+use tracing::{info, level_filters::LevelFilter};
 
 use crate::config::Config;
 
@@ -49,9 +48,28 @@ const HELP_STYLES: Styles = Styles::styled()
 pub struct CliArgs {
     #[command(subcommand)]
     pub command: Command,
+    /// Print source location and additional information in logs.
+    /// The default log level is INFO.
+    /// `-v` sets the log level to DEBUG.
+    /// `-vv` sets the log level to TRACE.
+    /// To change the log level, you can also use the `RELEASE_PLZ_LOG` environment variable. E.g. `RELEASE_PLZ_LOG=DEBUG`.
+    #[arg(
+        short,
+        long,
+        global = true,
+        action = clap::ArgAction::Count,
+    )]
+    verbose: u8,
+}
 
-    #[command(flatten, next_help_heading = "Logging Options")]
-    pub verbosity: Verbosity<InfoLevel>,
+impl CliArgs {
+    pub fn verbosity(&self) -> LevelFilter {
+        match self.verbose {
+            0 => LevelFilter::INFO,
+            1 => LevelFilter::DEBUG,
+            _ => LevelFilter::TRACE,
+        }
+    }
 }
 
 #[derive(clap::Subcommand, Debug)]

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -39,10 +39,7 @@ const HELP_STYLES: Styles = Styles::styled()
 
 /// Release-plz manages versioning, changelogs, and releases for Rust projects.
 ///
-/// See the Release-plz website for more information <https://release-plz.ieni.dev/>.
-///
-/// The default log level is INFO. To change it, set the `RELEASE_PLZ_LOG` environment variable or
-/// use the `--verbose` or `--quiet` flags.
+/// See the Release-plz website for more information <https://release-plz.dev/>.
 #[derive(clap::Parser, Debug)]
 #[command(version, author, styles = HELP_STYLES)]
 pub struct CliArgs {

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -47,10 +47,12 @@ pub struct CliArgs {
     pub command: Command,
     /// Print source location and additional information in logs.
     ///
-    /// The default log level is INFO.
-    /// `-v` sets the log level to DEBUG.
-    /// `-vv` sets the log level to TRACE.
-    /// To change the log level, you can also use the `RELEASE_PLZ_LOG` environment variable. E.g. `RELEASE_PLZ_LOG=DEBUG`.
+    /// If this option is unspecified, logs are printed at the INFO level without verbosity.
+    /// `-v` adds verbosity to logs.
+    /// `-vv` adds verbosity and sets the log level to DEBUG.
+    /// `-vvv` adds verbosity and sets the log level to TRACE.
+    /// To change the log level without setting verbosity, use the `RELEASE_PLZ_LOG`
+    /// environment variable. E.g. `RELEASE_PLZ_LOG=DEBUG`.
     #[arg(
         short,
         long,

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -46,6 +46,7 @@ pub struct CliArgs {
     #[command(subcommand)]
     pub command: Command,
     /// Print source location and additional information in logs.
+    ///
     /// The default log level is INFO.
     /// `-v` sets the log level to DEBUG.
     /// `-vv` sets the log level to TRACE.

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -17,6 +17,7 @@ use clap::{
     builder::{styling::AnsiColor, Styles},
     ValueEnum,
 };
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 use init::Init;
 use release_plz_core::fs_utils::current_directory;
 use set_version::SetVersion;
@@ -37,15 +38,20 @@ const HELP_STYLES: Styles = Styles::styled()
     .placeholder(SECONDARY_COLOR.on_default())
     .literal(SECONDARY_COLOR.on_default());
 
+/// Release-plz manages versioning, changelogs, and releases for Rust projects.
+///
+/// See the Release-plz website for more information <https://release-plz.ieni.dev/>.
+///
+/// The default log level is INFO. To change it, set the `RELEASE_PLZ_LOG` environment variable or
+/// use the `--verbose` or `--quiet` flags.
 #[derive(clap::Parser, Debug)]
-#[command(about, version, author, styles = HELP_STYLES)]
+#[command(version, author, styles = HELP_STYLES)]
 pub struct CliArgs {
     #[command(subcommand)]
     pub command: Command,
-    /// Print source location and additional information in logs.
-    /// To change the log level, use the `RUST_LOG` environment variable.
-    #[arg(short, long, global = true)]
-    pub verbose: bool,
+
+    #[command(flatten, next_help_heading = "Logging Options")]
+    pub verbosity: Verbosity<InfoLevel>,
 }
 
 #[derive(clap::Subcommand, Debug)]

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -10,7 +10,7 @@ mod update;
 
 use std::path::Path;
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use cargo_utils::CARGO_TOML;
 use clap::{
@@ -61,12 +61,15 @@ pub struct CliArgs {
 }
 
 impl CliArgs {
-    pub fn verbosity(&self) -> LevelFilter {
-        match self.verbose {
-            0 => LevelFilter::INFO,
-            1 => LevelFilter::DEBUG,
-            _ => LevelFilter::TRACE,
-        }
+    pub fn verbosity(&self) -> anyhow::Result<Option<LevelFilter>> {
+        let level = match self.verbose {
+            0 => None,
+            1 => Some(LevelFilter::INFO),
+            2 => Some(LevelFilter::DEBUG),
+            3 => Some(LevelFilter::TRACE),
+            _ => bail!("invalid verbosity level. Use -v, -vv, or -vvv."),
+        };
+        Ok(level)
     }
 }
 

--- a/crates/release_plz/src/log.rs
+++ b/crates/release_plz/src/log.rs
@@ -19,9 +19,13 @@ pub fn init(verbosity: LevelFilter) {
     let verbose = env_filter
         .max_level_hint()
         .is_some_and(|level| level > Level::INFO);
+
     let ignore_info_spans = filter_fn(move |metadata| {
-        verbose || !metadata.is_span() || metadata.level() < &Level::INFO
+        let is_trace_or_debug = || metadata.level() < &Level::INFO;
+        // If it's not a span, it's an event. We keep events.
+        verbose || !metadata.is_span() || is_trace_or_debug()
     });
+
     fmt()
         .with_env_filter(env_filter)
         .with_writer(std::io::stderr)

--- a/crates/release_plz/src/log.rs
+++ b/crates/release_plz/src/log.rs
@@ -20,7 +20,6 @@ pub fn init(verbosity: Option<LevelFilter>) {
             .from_env_lossy()
     });
 
-    // disable spans below WARN level span unless using user has increased verbosity
     let verbose = verbosity.is_some();
 
     let ignore_info_spans = filter_fn(move |metadata| {

--- a/crates/release_plz/src/log.rs
+++ b/crates/release_plz/src/log.rs
@@ -1,6 +1,6 @@
-use tracing::{level_filters::LevelFilter, Level};
+use tracing::{Level, level_filters::LevelFilter};
 use tracing_subscriber::{
-    filter::filter_fn, fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+    EnvFilter, filter::filter_fn, fmt, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
 /// Intialize the logging using the tracing crate

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -18,7 +18,7 @@ use crate::args::{manifest_command::ManifestCommand as _, CliArgs, Command};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
-    log::init(args.verbose);
+    log::init(args.verbosity.tracing_level_filter());
     run(args).await.map_err(|e| {
         error!("{:?}", e);
         e

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -18,7 +18,7 @@ use crate::args::{CliArgs, Command, manifest_command::ManifestCommand as _};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
-    log::init(args.verbosity.tracing_level_filter());
+    log::init(args.verbosity());
     run(args).await.map_err(|e| {
         error!("{:?}", e);
         e

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -18,7 +18,7 @@ use crate::args::{CliArgs, Command, manifest_command::ManifestCommand as _};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
-    log::init(args.verbosity());
+    log::init(args.verbosity()?);
     run(args).await.map_err(|e| {
         error!("{:?}", e);
         e

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -22,6 +22,7 @@ use super::{
 };
 
 const CRATES_DIR: &str = "crates";
+const RELEASE_PLZ_LOG: &str = "RELEASE_PLZ_LOG";
 
 /// It contains the universe in which release-plz runs.
 pub struct TestContext {
@@ -124,7 +125,7 @@ impl TestContext {
     pub fn run_update(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RELEASE_PLZ_LOG", log_level())
+            .env(RELEASE_PLZ_LOG, log_level())
             .arg("update")
             .arg("--verbose")
             .arg("--registry")
@@ -135,7 +136,7 @@ impl TestContext {
     pub fn run_release_pr(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RELEASE_PLZ_LOG", log_level())
+            .env(RELEASE_PLZ_LOG, log_level())
             .arg("release-pr")
             .arg("--verbose")
             .arg("--git-token")
@@ -153,7 +154,7 @@ impl TestContext {
     pub fn run_release(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RELEASE_PLZ_LOG", log_level())
+            .env(RELEASE_PLZ_LOG, log_level())
             .arg("release")
             .arg("--verbose")
             .arg("--git-token")
@@ -208,7 +209,7 @@ pub fn run_set_version(directory: &Utf8Path, change: &str) {
     let change: Vec<_> = change.split(' ').collect();
     super::cmd::release_plz_cmd()
         .current_dir(directory)
-        .env("RELEASE_PLZ_LOG", log_level())
+        .env(RELEASE_PLZ_LOG, log_level())
         .arg("set-version")
         .args(&change)
         .assert();
@@ -216,7 +217,7 @@ pub fn run_set_version(directory: &Utf8Path, change: &str) {
 
 fn log_level() -> String {
     if std::env::var("ENABLE_LOGS").is_ok() {
-        std::env::var("RELEASE_PLZ_LOG").unwrap_or("DEBUG,hyper=INFO".to_string())
+        std::env::var(RELEASE_PLZ_LOG).unwrap_or("DEBUG,hyper=INFO".to_string())
     } else {
         "ERROR".to_string()
     }

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -125,7 +125,7 @@ impl TestContext {
     pub fn run_update(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RUST_LOG", log_level())
+            .env("RELEASE_PLZ_LOG", log_level())
             .arg("update")
             .arg("--verbose")
             .arg("--registry")
@@ -136,7 +136,7 @@ impl TestContext {
     pub fn run_release_pr(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RUST_LOG", log_level())
+            .env("RELEASE_PLZ_LOG", log_level())
             .arg("release-pr")
             .arg("--verbose")
             .arg("--git-token")
@@ -153,7 +153,7 @@ impl TestContext {
     pub fn run_release(&self) -> Assert {
         super::cmd::release_plz_cmd()
             .current_dir(self.repo_dir())
-            .env("RUST_LOG", log_level())
+            .env("RELEASE_PLZ_LOG", log_level())
             .arg("release")
             .arg("--verbose")
             .arg("--git-token")
@@ -207,7 +207,7 @@ pub fn run_set_version(directory: &Utf8Path, change: &str) {
     let change: Vec<_> = change.split(' ').collect();
     super::cmd::release_plz_cmd()
         .current_dir(directory)
-        .env("RUST_LOG", log_level())
+        .env("RELEASE_PLZ_LOG", log_level())
         .arg("set-version")
         .args(&change)
         .assert();
@@ -215,7 +215,7 @@ pub fn run_set_version(directory: &Utf8Path, change: &str) {
 
 fn log_level() -> String {
     if std::env::var("ENABLE_LOGS").is_ok() {
-        std::env::var("RUST_LOG").unwrap_or("DEBUG,hyper=INFO".to_string())
+        std::env::var("RELEASE_PLZ_LOG").unwrap_or("DEBUG,hyper=INFO".to_string())
     } else {
         "ERROR".to_string()
     }

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -40,13 +40,13 @@ It can be specified multiple times to increase the verbosity even more.
 
 ```bash
 release-plz --verbose # (or -v) Make logs verbose
-release-plz -vv # Show verbose debug logs
-release-plz -vvv # Show verbose trace logs
+release-plz -vv # Show verbose DEBUG logs
+release-plz -vvv # Show verbose TRACE logs
 ```
 
 Release-plz log level can also be configured using the `RELEASE_PLZ_LOG` environment variable.
 
 ```bash
-RELEASE_PLZ_LOG=debug release-plz
-RELEASE_PLZ_LOG=trace release-plz
+RELEASE_PLZ_LOG=DEBUG release-plz
+RELEASE_PLZ_LOG=TRACE release-plz
 ```

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -35,15 +35,16 @@ is having issues to:
 
 By default, Release-plz shows logs at the `INFO` level.
 
-The `--verbose` (`-v`) flag can be used to increase the verbosity of the logs. It can be specified
-multiple times to increase the verbosity even more.
+The `--verbose` (`-v`) flag can be used to increase the verbosity of the logs.
+It can be specified multiple times to increase the verbosity even more.
 
 ```bash
-release-plz --verbose # Show debug logs
-release-plz -vv # Show trace logs
+release-plz --verbose # (or -v) Make logs verbose
+release-plz -vv # Show verbose debug logs
+release-plz -vvv # Show verbose trace logs
 ```
 
-Release-plz can also be configured using the `RELEASE_PLZ_LOG` environment variable.
+Release-plz log level can also be configured using the `RELEASE_PLZ_LOG` environment variable.
 
 ```bash
 RELEASE_PLZ_LOG=debug release-plz

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -33,7 +33,19 @@ is having issues to:
 
 ## See `DEBUG` logs
 
-Release-plz uses the `RUST_LOG` environment variable to filter the level of the printed logs.
-By default, release-plz shows logs at the `info` level, or more severe.
-To see debug logs, use `RUST_LOG=debug release-plz`.
-If you want something even more details, use `RUST_LOG=trace release-plz`
+By default, Release-plz shows logs at the `INFO` level.
+
+The `--verbose` (`-v`) flag can be used to increase the verbosity of the logs. It can be specified
+multiple times to increase the verbosity even more.
+
+```bash
+release-plz --verbose # Show debug logs
+release-plz -vv # Show trace logs
+```
+
+Release-plz can also be configured using the `RELEASE_PLZ_LOG` environment variable.
+
+```bash
+RELEASE_PLZ_LOG=debug release-plz
+RELEASE_PLZ_LOG=trace release-plz
+```


### PR DESCRIPTION
Addresses parts of https://github.com/release-plz/release-plz/issues/2060

- Use RELEASE_PLZ_LOG env var to control logging level
- ~Use clap-verbosity-flag to add --verbose and --quiet flags to the cli~
- Fallback to RUST_LOG if RELEASE_PLZ_LOG is not set (for backwards
  compatibility)
- Remove "pretty" styled logs - these make the logs harder to read as
  when viewing them in a github action as the information is split over
  multiple lines
- Use simpler tracing_subscriber config (`fmt()` and `init()`)
- Remove tracing-log dependency (this is enabled by default by `init()`)

# Default
![image](https://github.com/user-attachments/assets/b07cf988-3517-41f3-9c01-aea28618d51a)

# Verbose
![image](https://github.com/user-attachments/assets/9c74a81d-bfbf-4fa1-a842-06854ae9007a)

# Trace (can also be enabled using `-vv` or `--verbose --verbose`)
![image](https://github.com/user-attachments/assets/455d4399-c402-4f45-aa3c-c365753755ea)

---

As a side note, I'd generally suggest that keeping the target on by default is a good thing to do as knowing where a log message comes from is one of the main things a log output should tell you. I haven't made that change here.