### PR TITLE
fix: restore pr link expansion on non-conventional commits

### DIFF
--- a/crates/release_plz/tests/all/changelog.rs
+++ b/crates/release_plz/tests/all/changelog.rs
@@ -2,7 +2,7 @@ use release_plz_core::fs_utils::Utf8TempDir;
 
 use crate::helpers::{
     package::{PackageType, TestPackage},
-    test_context::TestContext,
+    test_context::TestContext, today,
 };
 
 #[tokio::test]
@@ -358,6 +358,7 @@ async fn pr_link_is_expanded() {
 
     let username = context.gitea.user.username();
     let package = &context.gitea.repo;
+    let today = today();
     assert_eq!(
         changelog.trim(),
         format!(
@@ -371,7 +372,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0](https://localhost/{username}/{package}/releases/tag/v0.1.0) - 2025-03-01
+## [0.1.0](https://localhost/{username}/{package}/releases/tag/v0.1.0) - {today}
 
 ### Added
 

--- a/crates/release_plz/tests/all/changelog.rs
+++ b/crates/release_plz/tests/all/changelog.rs
@@ -340,11 +340,17 @@ async fn raw_message_contains_entire_commit_message() {
 async fn pr_link_is_expanded() {
     let context = TestContext::new().await;
 
-    let new_file = context.repo_dir().join("new.rs");
-    fs_err::write(&new_file, "// hi").unwrap();
-    // in the `raw_message` you should see the entire message, including `commit body`
-    context.push_to_pr("feat: new file").await;
-    context.merge_all_prs().await;
+    let open_and_merge_pr = async |file, commit, branch| {
+        let new_file = context.repo_dir().join(file);
+        fs_err::write(&new_file, "// hi").unwrap();
+        // in the `raw_message` you should see the entire message, including `commit body`
+        context.push_to_pr(commit, branch).await;
+        context.merge_all_prs().await;
+    };
+
+    // make sure PR is expanded for both conventional and non-conventional commits
+    open_and_merge_pr("new1.rs", "feat: new file", "pr1").await;
+    open_and_merge_pr("new2.rs", "non-conventional commit", "pr2").await;
 
     context.run_update().success();
 
@@ -373,6 +379,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- non-conventional commit ([#2](https://localhost/{username}/{package}/pulls/2))
 - cargo init
 - Initial commit"#,
         )

--- a/crates/release_plz/tests/all/changelog.rs
+++ b/crates/release_plz/tests/all/changelog.rs
@@ -2,7 +2,8 @@ use release_plz_core::fs_utils::Utf8TempDir;
 
 use crate::helpers::{
     package::{PackageType, TestPackage},
-    test_context::TestContext, today,
+    test_context::TestContext,
+    today,
 };
 
 #[tokio::test]

--- a/crates/release_plz/tests/all/helpers/mod.rs
+++ b/crates/release_plz/tests/all/helpers/mod.rs
@@ -6,3 +6,8 @@ mod reqwest_utils;
 pub mod test_context;
 
 pub const TEST_REGISTRY: &str = "test-registry";
+
+pub fn today() -> String {
+    // The changelogs specify the release date in UTC.
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -64,13 +64,13 @@ impl TestContext {
         self.repo.git(&["push"]).unwrap();
     }
 
-    pub async fn push_to_pr(&self, commit_message: &str) {
-        self.repo.git(&["checkout", "-b", "my-pr"]).unwrap();
+    pub async fn push_to_pr(&self, commit_message: &str, branch: &str) {
+        self.repo.git(&["checkout", "-b", branch]).unwrap();
         self.repo.add_all_and_commit(commit_message).unwrap();
-        self.repo.git(&["push", "origin", "my-pr"]).unwrap();
+        self.repo.git(&["push", "origin", branch]).unwrap();
         let pr = Pr {
             base_branch: "main".to_string(),
-            branch: "my-pr".to_string(),
+            branch: branch.to_string(),
             title: commit_message.to_string(),
             body: "This is my pull request".to_string(),
             draft: false,

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -8,7 +8,7 @@ use cargo_metadata::{
 };
 use git_cmd::Repo;
 use release_plz_core::{
-    DEFAULT_BRANCH_PREFIX, GitBackend, GitClient, GitPr, Gitea, RepoUrl,
+    DEFAULT_BRANCH_PREFIX, GitBackend, GitClient, GitPr, Gitea, Pr, RepoUrl,
     fs_utils::{Utf8TempDir, canonicalize_utf8},
 };
 use secrecy::SecretString;
@@ -64,6 +64,23 @@ impl TestContext {
         self.repo.git(&["push"]).unwrap();
     }
 
+    pub async fn push_to_pr(&self, commit_message: &str) {
+        self.repo.git(&["checkout", "-b", "my-pr"]).unwrap();
+        self.repo.add_all_and_commit(commit_message).unwrap();
+        self.repo.git(&["push", "origin", "my-pr"]).unwrap();
+        let pr = Pr {
+            base_branch: "main".to_string(),
+            branch: "my-pr".to_string(),
+            title: commit_message.to_string(),
+            body: "This is my pull request".to_string(),
+            draft: false,
+            labels: vec![],
+        };
+        self.git_client.open_pr(&pr).await.unwrap();
+        // go back to main
+        self.repo.git(&["checkout", "-"]).unwrap();
+    }
+
     pub async fn new() -> Self {
         let context = Self::init_context().await;
         let package = TestPackage::new(&context.gitea.repo);
@@ -105,6 +122,14 @@ impl TestContext {
         context.generate_cargo_lock();
         context.push_all_changes("cargo init");
         context
+    }
+
+    pub async fn merge_all_prs(&self) {
+        let opened_prs = self.git_client.opened_prs("").await.unwrap();
+        for pr in opened_prs {
+            self.gitea.merge_pr_retrying(pr.number).await;
+        }
+        self.repo.git(&["pull"]).unwrap();
     }
 
     pub async fn merge_release_pr(&self) {

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{
     package::{PackageType, TestPackage},
-    test_context::TestContext, today,
+    test_context::TestContext,
+    today,
 };
 use cargo_utils::{CARGO_TOML, LocalManifest};
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
     package::{PackageType, TestPackage},
-    test_context::TestContext,
+    test_context::TestContext, today,
 };
 use cargo_utils::{CARGO_TOML, LocalManifest};
 
@@ -649,9 +649,4 @@ fn move_readme(context: &TestContext, message: &str) {
     cargo_toml.write().unwrap();
 
     context.push_all_changes(message);
-}
-
-fn today() -> String {
-    // The changelogs specify the release date in UTC.
-    chrono::Utc::now().format("%Y-%m-%d").to_string()
 }

--- a/crates/release_plz_core/src/diff.rs
+++ b/crates/release_plz_core/src/diff.rs
@@ -24,14 +24,12 @@ pub struct Commit {
     pub author: Signature,
     pub committer: Signature,
     pub remote: RemoteContributor,
-    pub raw_message: String,
 }
 
 impl Commit {
     pub fn new(id: String, message: String) -> Self {
         Self {
             id,
-            raw_message: message.clone(),
             message,
             ..Self::default()
         }
@@ -49,7 +47,6 @@ impl Commit {
             message: self.message.clone(),
             author: self.author.clone(),
             committer: self.committer.clone(),
-            raw_message: Some(self.raw_message.clone()),
             remote,
             ..Default::default()
         }

--- a/crates/release_plz_core/src/lib.rs
+++ b/crates/release_plz_core/src/lib.rs
@@ -37,6 +37,6 @@ pub use git::gitlab_client::GitLab;
 pub use next_ver::*;
 pub use package_compare::*;
 pub use package_path::*;
-pub use pr::DEFAULT_BRANCH_PREFIX;
+pub use pr::{DEFAULT_BRANCH_PREFIX, Pr};
 pub use project::*;
 pub use repo_url::*;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
`(#xxx)` in changelog is replaced with `([#xxx](https://github.com/release-plz/release-plz/pull/xxx))`