### PR TITLE
fix: escape the curly braces in the template for init

### DIFF
--- a/crates/release_plz/src/init/mod.rs
+++ b/crates/release_plz/src/init/mod.rs
@@ -153,7 +153,7 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == '{owner}' }}
+    if: ${{{{ github.repository_owner == '{owner}' }}}}
     permissions:
       contents: write
     steps:
@@ -174,7 +174,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == '{owner}' }}
+    if: ${{{{ github.repository_owner == '{owner}' }}}}
     permissions:
       pull-requests: write
       contents: write
@@ -249,7 +249,7 @@ mod tests {
               release-plz-release:
                 name: Release-plz release
                 runs-on: ubuntu-latest
-                if: ${ github.repository_owner == 'owner' }
+                if: ${{ github.repository_owner == 'owner' }}
                 permissions:
                   contents: write
                 steps:
@@ -270,7 +270,7 @@ mod tests {
               release-plz-pr:
                 name: Release-plz PR
                 runs-on: ubuntu-latest
-                if: ${ github.repository_owner == 'owner' }
+                if: ${{ github.repository_owner == 'owner' }}
                 permissions:
                   pull-requests: write
                   contents: write
@@ -309,7 +309,7 @@ mod tests {
               release-plz-release:
                 name: Release-plz release
                 runs-on: ubuntu-latest
-                if: ${ github.repository_owner == 'owner' }
+                if: ${{ github.repository_owner == 'owner' }}
                 permissions:
                   contents: write
                 steps:
@@ -331,7 +331,7 @@ mod tests {
               release-plz-pr:
                 name: Release-plz PR
                 runs-on: ubuntu-latest
-                if: ${ github.repository_owner == 'owner' }
+                if: ${{ github.repository_owner == 'owner' }}
                 permissions:
                   pull-requests: write
                   contents: write


### PR DESCRIPTION
I generated the `.github/workflows/release-plz.yml` file using the `release-plz init` command, but encountered a [CI failure](https://github.com/jmjoy/comfyui-client/actions/runs/13896093222/workflow). The failure occurred because the `{}` characters in the `format!` macro are special syntax elements that require escaping.