### PR TITLE
fix: ignore global `.gitignore` when copying to tmp dir

### DIFF
--- a/crates/release_plz_core/src/copy_dir.rs
+++ b/crates/release_plz_core/src/copy_dir.rs
@@ -53,6 +53,8 @@ fn copy_directory(from: &Utf8Path, to: Utf8PathBuf) -> Result<(), anyhow::Error>
         .hidden(false)
         // Don't consider `.ignore` files.
         .ignore(false)
+        // Ignore the global `.gitignore` as it might cause issues.
+        // For example, if it contains `.git/`, we will fail in recognizing the git directory later.
         .git_global(false)
         .build();
     for entry in walker {

--- a/crates/release_plz_core/src/copy_dir.rs
+++ b/crates/release_plz_core/src/copy_dir.rs
@@ -53,6 +53,7 @@ fn copy_directory(from: &Utf8Path, to: Utf8PathBuf) -> Result<(), anyhow::Error>
         .hidden(false)
         // Don't consider `.ignore` files.
         .ignore(false)
+        .git_global(false)
         .build();
     for entry in walker {
         let entry = entry.context("invalid entry")?;


### PR DESCRIPTION
By default, `ignore::WalkBuilder::new` ignores patterns listed in the global `.gitignore`. In case a CI runner contains `.git/` in its global `.gitignore`, release-plz fails on finding the local repository and current branch after copying the repository to a temp dir.

```
...
 1: failed to determine local project repository
 2: cannot determine current branch
```

This PR therefore changes the code to ignore the global `.gitignore` when walking the directory tree.
