### PR TITLE
feat: Alias the `--backend` flag to `--forge`

### DIFF
--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -52,7 +52,7 @@ pub struct Release {
     #[arg(long, value_parser = NonEmptyStringValueParser::new(), env, hide_env_values=true)]
     pub git_token: Option<String>,
     /// Kind of git forge
-    #[arg(long, alias = "backend", value_enum, default_value_t = ReleaseGitForgeKind::Github)]
+    #[arg(long, visible_alias = "backend", value_enum, default_value_t = ReleaseGitForgeKind::Github)]
     forge: ReleaseGitForgeKind,
     /// Path to the release-plz config file.
     /// Default: `./release-plz.toml`.

--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -9,7 +9,7 @@ use clap::{
 };
 use git_cliff_core::config::Config as GitCliffConfig;
 use release_plz_core::{
-    ChangelogRequest, GitBackend, GitHub, GitLab, Gitea, RepoUrl, fs_utils::to_utf8_path,
+    ChangelogRequest, GitForge, GitHub, GitLab, Gitea, RepoUrl, fs_utils::to_utf8_path,
     update_request::UpdateRequest,
 };
 use secrecy::SecretString;
@@ -103,12 +103,12 @@ pub struct Update {
     #[arg(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github-token", env, hide_env_values=true)]
     pub git_token: Option<String>,
     /// Kind of git host where your project is hosted.
-    #[arg(long, value_enum, default_value_t = GitBackendKind::Github)]
-    backend: GitBackendKind,
+    #[arg(long, alias = "backend", value_enum, default_value_t = GitForgeKind::Github)]
+    forge: GitForgeKind,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GitBackendKind {
+pub enum GitForgeKind {
     #[value(name = "github")]
     Github,
     #[value(name = "gitea")]
@@ -136,21 +136,21 @@ impl ConfigCommand for Update {
 }
 
 impl Update {
-    pub fn git_backend(&self, repo: RepoUrl) -> anyhow::Result<Option<GitBackend>> {
+    pub fn git_forge(&self, repo: RepoUrl) -> anyhow::Result<Option<GitForge>> {
         let Some(token) = self.git_token.clone() else {
             return Ok(None);
         };
         let token = SecretString::from(token);
-        Ok(Some(match self.backend {
-            GitBackendKind::Github => {
+        Ok(Some(match self.forge {
+            GitForgeKind::Github => {
                 anyhow::ensure!(
                     repo.is_on_github(),
-                    "Can't create PR: the repository is not hosted in GitHub. Please select a different backend."
+                    "Can't create PR: the repository is not hosted in GitHub. Please select a different forge."
                 );
-                GitBackend::Github(GitHub::new(repo.owner, repo.name, token))
+                GitForge::Github(GitHub::new(repo.owner, repo.name, token))
             }
-            GitBackendKind::Gitea => GitBackend::Gitea(Gitea::new(repo, token)?),
-            GitBackendKind::Gitlab => GitBackend::Gitlab(GitLab::new(repo, token)?),
+            GitForgeKind::Gitea => GitForge::Gitea(Gitea::new(repo, token)?),
+            GitForgeKind::Gitlab => GitForge::Gitlab(GitLab::new(repo, token)?),
         }))
     }
 
@@ -219,7 +219,7 @@ impl Update {
             update = update.with_release_commits(release_commits)?;
         }
         if let Some(repo) = update.repo_url() {
-            if let Some(git_client) = self.git_backend(repo.clone())? {
+            if let Some(git_client) = self.git_forge(repo.clone())? {
                 update = update.with_git_client(git_client);
             }
         }
@@ -306,7 +306,7 @@ mod tests {
             allow_dirty: false,
             repo_url: None,
             config: None,
-            backend: GitBackendKind::Github,
+            forge: GitForgeKind::Github,
             git_token: None,
         };
         let config: Config = toml::from_str("").unwrap();

--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -103,7 +103,7 @@ pub struct Update {
     #[arg(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github-token", env, hide_env_values=true)]
     pub git_token: Option<String>,
     /// Kind of git host where your project is hosted.
-    #[arg(long, alias = "backend", value_enum, default_value_t = GitForgeKind::Github)]
+    #[arg(long, visible_alias = "backend", value_enum, default_value_t = GitForgeKind::Github)]
     forge: GitForgeKind,
 }
 

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -8,7 +8,7 @@ use cargo_metadata::{
 };
 use git_cmd::Repo;
 use release_plz_core::{
-    DEFAULT_BRANCH_PREFIX, GitBackend, GitClient, GitPr, Gitea, Pr, RepoUrl,
+    DEFAULT_BRANCH_PREFIX, GitClient, GitForge, GitPr, Gitea, Pr, RepoUrl,
     fs_utils::{Utf8TempDir, canonicalize_utf8},
 };
 use secrecy::SecretString;
@@ -166,7 +166,7 @@ impl TestContext {
             .arg("--verbose")
             .arg("--git-token")
             .arg(&self.gitea.token)
-            .arg("--backend")
+            .arg("--forge")
             .arg("gitea")
             .arg("--registry")
             .arg(TEST_REGISTRY)
@@ -184,7 +184,7 @@ impl TestContext {
             .arg("--verbose")
             .arg("--git-token")
             .arg(&self.gitea.token)
-            .arg("--backend")
+            .arg("--forge")
             .arg("gitea")
             .arg("--registry")
             .arg(TEST_REGISTRY)
@@ -291,14 +291,14 @@ git-fetch-with-cli = true
 }
 
 fn git_client(repo_url: &str, token: &str) -> GitClient {
-    let git_backend = GitBackend::Gitea(
+    let git_forge = GitForge::Gitea(
         Gitea::new(
             RepoUrl::new(repo_url).unwrap(),
             SecretString::from(token.to_string()),
         )
         .unwrap(),
     );
-    GitClient::new(git_backend).unwrap()
+    GitClient::new(git_forge).unwrap()
 }
 
 fn git_clone(path: &Utf8Path, repo_url: &str) {

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -18,12 +18,12 @@ use tracing::{debug, info, instrument, warn};
 use url::Url;
 
 use crate::{
-    CHANGELOG_FILENAME, DEFAULT_BRANCH_PREFIX, GitBackend, PackagePath, Project, Publishable as _,
+    CHANGELOG_FILENAME, DEFAULT_BRANCH_PREFIX, GitForge, PackagePath, Project, Publishable as _,
     ReleaseMetadata, ReleaseMetadataBuilder, Remote,
     cargo::{CargoIndex, CargoRegistry, CmdOutput, is_published, run_cargo, wait_until_published},
     cargo_hash_kind::get_hash_kind,
     changelog_parser,
-    git::backend::GitClient,
+    git::forge::GitClient,
     pr_parser::{Pr, prs_from_text},
 };
 
@@ -508,8 +508,8 @@ impl GitTagConfig {
 
 #[derive(Debug)]
 pub struct GitRelease {
-    /// Kind of Git Backend.
-    pub backend: GitBackend,
+    /// Kind of Git Forge.
+    pub forge: GitForge,
 }
 
 #[derive(Serialize, Default, Debug)]
@@ -699,7 +699,7 @@ async fn should_release(
     }
 }
 
-fn is_pr_commit_in_original_branch(repo: &Repo, commit: &crate::git::backend::PrCommit) -> bool {
+fn is_pr_commit_in_original_branch(repo: &Repo, commit: &crate::git::forge::PrCommit) -> bool {
     let branches_of_commit = repo.get_branches_of_commit(&commit.sha);
     if let Ok(branches) = branches_of_commit {
         branches.contains(&repo.original_branch().to_string())
@@ -931,8 +931,8 @@ fn get_git_client(input: &ReleaseRequest) -> anyhow::Result<GitClient> {
     let git_release = input
         .git_release
         .as_ref()
-        .context("git release not configured. Did you specify git-token and backend?")?;
-    GitClient::new(git_release.backend.clone())
+        .context("git release not configured. Did you specify git-token and forge?")?;
+    GitClient::new(git_release.forge.clone())
 }
 
 #[derive(Debug)]

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 use tracing::{debug, info, instrument};
 use url::Url;
 
-use crate::git::backend::{
-    BackendType, GitClient, GitPr, PrEdit, contributors_from_commits, validate_labels,
+use crate::git::forge::{
+    ForgeType, GitClient, GitPr, PrEdit, contributors_from_commits, validate_labels,
 };
 use crate::git::github_graphql;
 use crate::pr::{DEFAULT_BRANCH_PREFIX, OLD_BRANCH_PREFIX, Pr};
@@ -305,7 +305,7 @@ async fn handle_opened_pr(
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
     repo.checkout_new_branch(&pr.branch)?;
-    if matches!(git_client.backend, BackendType::Github) {
+    if matches!(git_client.forge, ForgeType::Github) {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
         create_release_branch(repo, &pr.branch, &pr.title)?;
@@ -330,7 +330,7 @@ async fn update_pr(
             repository.original_branch()
         )
     })?;
-    if matches!(git_client.backend, BackendType::Github) {
+    if matches!(git_client.forge, ForgeType::Github) {
         github_force_push(git_client, opened_pr, repository).await?;
     } else {
         force_push(opened_pr, repository)?;

--- a/crates/release_plz_core/src/command/update/update_request.rs
+++ b/crates/release_plz_core/src/command/update/update_request.rs
@@ -10,7 +10,7 @@ use cargo_metadata::{
 };
 use regex::Regex;
 
-use crate::{ChangelogRequest, GitBackend, GitClient, PackagePath as _, RepoUrl, fs_utils};
+use crate::{ChangelogRequest, GitClient, GitForge, PackagePath as _, RepoUrl, fs_utils};
 
 use super::update_config::{PackageUpdateConfig, UpdateConfig};
 
@@ -44,7 +44,7 @@ pub struct UpdateRequest {
     /// Release Commits
     /// Prepare release only if at least one commit respects a regex.
     release_commits: Option<Regex>,
-    git: Option<GitBackend>,
+    git: Option<GitForge>,
 }
 
 impl UpdateRequest {
@@ -99,7 +99,7 @@ impl UpdateRequest {
         })
     }
 
-    pub fn with_git_client(self, git: GitBackend) -> Self {
+    pub fn with_git_client(self, git: GitForge) -> Self {
         Self {
             git: Some(git),
             ..self

--- a/crates/release_plz_core/src/git/gitea_client.rs
+++ b/crates/release_plz_core/src/git/gitea_client.rs
@@ -1,5 +1,5 @@
 use crate::RepoUrl;
-use crate::git::backend::Remote;
+use crate::git::forge::Remote;
 use anyhow::{Context, bail};
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;

--- a/crates/release_plz_core/src/git/github_client.rs
+++ b/crates/release_plz_core/src/git/github_client.rs
@@ -3,7 +3,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use url::Url;
 
-use crate::git::backend::Remote;
+use crate::git::forge::Remote;
 
 #[derive(Debug, Clone)]
 pub struct GitHub {

--- a/crates/release_plz_core/src/git/github_graphql.rs
+++ b/crates/release_plz_core/src/git/github_graphql.rs
@@ -7,7 +7,7 @@ use tracing::{debug, trace};
 use url::Url;
 
 use crate::GitClient;
-use crate::git::backend::Remote;
+use crate::git::forge::Remote;
 
 /// Commit all the changes (except typestates) that are present in the repository
 /// using GitHub's [GraphQL api](https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch).

--- a/crates/release_plz_core/src/git/gitlab_client.rs
+++ b/crates/release_plz_core/src/git/gitlab_client.rs
@@ -3,7 +3,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use tracing::debug;
 
-use crate::{RepoUrl, git::backend::Remote};
+use crate::{RepoUrl, git::forge::Remote};
 
 #[derive(Debug, Clone)]
 pub struct GitLab {

--- a/crates/release_plz_core/src/git/mod.rs
+++ b/crates/release_plz_core/src/git/mod.rs
@@ -1,4 +1,4 @@
-pub mod backend;
+pub mod forge;
 pub mod gitea_client;
 pub mod github_client;
 pub mod github_graphql;

--- a/crates/release_plz_core/src/lib.rs
+++ b/crates/release_plz_core/src/lib.rs
@@ -30,7 +30,7 @@ mod version;
 pub use changelog::*;
 pub use command::*;
 pub use download::{PackageDownloader, read_package};
-pub use git::backend::{GitBackend, GitClient, GitPr};
+pub use git::forge::{GitClient, GitForge, GitPr};
 pub use git::gitea_client::Gitea;
 pub use git::github_client::GitHub;
 pub use git::gitlab_client::GitLab;

--- a/crates/release_plz_core/tests/all/helpers/comparison_test.rs
+++ b/crates/release_plz_core/tests/all/helpers/comparison_test.rs
@@ -4,7 +4,7 @@ use cargo_metadata::camino::Utf8PathBuf;
 use cargo_utils::{CARGO_TOML, get_manifest_metadata};
 use chrono::NaiveDate;
 use release_plz_core::{
-    CHANGELOG_FILENAME, ChangelogRequest, GitBackend, GitHub, Gitea, ReleasePrRequest, RepoUrl,
+    CHANGELOG_FILENAME, ChangelogRequest, GitForge, GitHub, Gitea, ReleasePrRequest, RepoUrl,
     are_packages_equal, copy_to_temp_dir, fs_utils::Utf8TempDir, update_request::UpdateRequest,
 };
 use secrecy::SecretString;
@@ -64,7 +64,7 @@ impl ComparisonTest {
     }
 
     fn github_release_pr_request(&self, base_url: Url) -> ReleasePrRequest {
-        let github = GitBackend::Github(
+        let github = GitForge::Github(
             GitHub::new(
                 OWNER.to_string(),
                 REPO.to_string(),
@@ -86,7 +86,7 @@ impl ComparisonTest {
     fn gitea_release_pr_request(&self, base_url: &Url) -> anyhow::Result<ReleasePrRequest> {
         let url = RepoUrl::new(&format!("{}{OWNER}/{REPO}", base_url.as_str()))
             .context("can't crate url")?;
-        let git = GitBackend::Gitea(Gitea::new(url, SecretString::from("token".to_string()))?);
+        let git = GitForge::Gitea(Gitea::new(url, SecretString::from("token".to_string()))?);
         let update_request = self.update_request().with_git_client(git);
         Ok(ReleasePrRequest::new(update_request))
     }

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -54,7 +54,7 @@ To do so, you can:
 - Query the `/pulls` GitHub
   [endpoint](https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests).
   For example, release-plz does it
-  [here](https://github.com/release-plz/release-plz/blob/a92629ed10b8bb42dde426c0f0001aebbb6fa70e/crates/release_plz_core/src/git/forge.rs#L238).
+  [here](https://github.com/release-plz/release-plz/blob/a92629ed10b8bb42dde426c0f0001aebbb6fa70e/crates/release_plz_core/src/git/backend.rs#L238).
 - Use `git tag | grep release-plz`.
 
 If none of these options work for you or you want release-plz to output

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -54,7 +54,7 @@ To do so, you can:
 - Query the `/pulls` GitHub
   [endpoint](https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests).
   For example, release-plz does it
-  [here](https://github.com/release-plz/release-plz/blob/a92629ed10b8bb42dde426c0f0001aebbb6fa70e/crates/release_plz_core/src/git/backend.rs#L238).
+  [here](https://github.com/release-plz/release-plz/blob/a92629ed10b8bb42dde426c0f0001aebbb6fa70e/crates/release_plz_core/src/git/forge.rs#L238).
 - Use `git tag | grep release-plz`.
 
 If none of these options work for you or you want release-plz to output

--- a/website/docs/github/input.md
+++ b/website/docs/github/input.md
@@ -17,7 +17,7 @@ The GitHub action accepts the following input variables:
 - `token`: Token used to publish to the cargo registry.
   Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
   environment variable, used for registry specified in the `registry` input variable.
-- `forge` or `backend`: Git backend/forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`).*
+- `forge` (previously `backend`): Git backend/forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`)*.
 - `verbose`: Print module and source location in logs.
   I.e. adds the `-v` flag to the command. *(Defaults to `false`).*
 

--- a/website/docs/github/input.md
+++ b/website/docs/github/input.md
@@ -17,7 +17,7 @@ The GitHub action accepts the following input variables:
 - `token`: Token used to publish to the cargo registry.
   Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
   environment variable, used for registry specified in the `registry` input variable.
-- `backend`: Forge backend. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`).*
+- `forge` or `backend`: Git backend/forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`).*
 - `verbose`: Print module and source location in logs.
   I.e. adds the `-v` flag to the command. *(Defaults to `false`).*
 

--- a/website/docs/github/input.md
+++ b/website/docs/github/input.md
@@ -17,7 +17,7 @@ The GitHub action accepts the following input variables:
 - `token`: Token used to publish to the cargo registry.
   Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
   environment variable, used for registry specified in the `registry` input variable.
-- `forge` (previously `backend`): Git backend/forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`)*.
+- `forge` (previously `backend`): Git forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`)*.
 - `verbose`: Print module and source location in logs.
   I.e. adds the `-v` flag to the command. *(Defaults to `false`).*
 

--- a/website/docs/github/input.md
+++ b/website/docs/github/input.md
@@ -17,7 +17,8 @@ The GitHub action accepts the following input variables:
 - `token`: Token used to publish to the cargo registry.
   Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
   environment variable, used for registry specified in the `registry` input variable.
-- `forge` (previously `backend`): Git forge. Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`)*.
+- `forge` (previously `backend`): Git forge.
+  Valid values: `github`, `gitea`, `gitlab`. *(Defaults to `github`)*.
 - `verbose`: Print module and source location in logs.
   I.e. adds the `-v` flag to the command. *(Defaults to `false`).*
 

--- a/website/docs/usage/release-pr.md
+++ b/website/docs/usage/release-pr.md
@@ -60,7 +60,7 @@ commit without specifying a GPG signature.
 ## GitLab
 
 `release-plz release-pr` also supports creating PRs for repositories hosted on GitLab with
-the `--forge gitlab` or `--backend gitlab` option.
+the `--forge gitlab` option.
 
 You need to create a token in your GitLab repo (Settings/Access Tokens) with the following
 permissions:

--- a/website/docs/usage/release-pr.md
+++ b/website/docs/usage/release-pr.md
@@ -40,7 +40,7 @@ Instead, release-plz overrides the existing release PR with the changes of the s
 ## Gitea
 
 `release-plz release-pr` also supports creating PRs for repositories hosted on
-Gitea with the `--forge` or `backend` option:
+Gitea with the `--forge` option:
 
 `release-plz release-pr --git-token <gitea application token> --forge gitea`
 

--- a/website/docs/usage/release-pr.md
+++ b/website/docs/usage/release-pr.md
@@ -40,9 +40,9 @@ Instead, release-plz overrides the existing release PR with the changes of the s
 ## Gitea
 
 `release-plz release-pr` also supports creating PRs for repositories hosted on
-Gitea with the `--backend` option:
+Gitea with the `--forge` or `backend` option:
 
-`release-plz release-pr --git-token <gitea application token> --backend gitea`
+`release-plz release-pr --git-token <gitea application token> --forge gitea`
 
 The token needs to have the following permissions:
 
@@ -60,7 +60,7 @@ commit without specifying a GPG signature.
 ## GitLab
 
 `release-plz release-pr` also supports creating PRs for repositories hosted on GitLab with
-the `--backend gitlab` option.
+the `--forge gitlab` or `--backend gitlab` option.
 
 You need to create a token in your GitLab repo (Settings/Access Tokens) with the following
 permissions:
@@ -75,7 +75,7 @@ docs.
 
 Then you can run `release-plz release-pr` with the following arguments:
 
-`release-plz release-pr --backend gitlab --git-token <gitlab_token>`
+`release-plz release-pr --forge gitlab --git-token <gitlab_token>`
 
 ## Json output
 

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -27,15 +27,15 @@ If all packages are already published, the `release-plz release` command does no
 
 To learn more, run `release-plz release --help`.
 
-## Git Backends
+## Git Forges
 
-GitHub is the default release-plz backend. You can use the `--backend` flag to
-specify a different backend.
+GitHub is the default release-plz forge. You can use the `--forge` flag to
+specify a different forge.
 
 ### GitLab
 
 `release-plz release` also supports creating releases for repositories hosted on GitLab with
-the `--backend gitlab` option:
+the `--forge gitlab` option:
 
 You need to create a token in your GitLab repo (Settings/Access Tokens) with the following
 permissions:
@@ -50,15 +50,15 @@ docs.
 
 Then you can run `release-plz release` with the following arguments:
 
-`release-plz release --backend gitlab --git-token <gitlab_token>`
+`release-plz release --forge gitlab --git-token <gitlab_token>`
 
 ### Gitea
 
-`releases-plz` supports creating releases on Gitea with the `--backend gitea` option.
+`releases-plz` supports creating releases on Gitea with the `--forge gitea` option.
 
 Then you can run `release-plz release` in Gitea CI with the following arguments:
 
-`release-plz release --backend gitea --git-token <gitea_token>`
+`release-plz release --forge gitea --git-token <gitea_token>`
 
 The token needs to have the following permissions:
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->
These changes rename "git backend" to "git forge" in the CLI flags, error messages and documentation and other rust files.

It adds the `alias = backend` attribute in the `Release` and `Update` structs to support retrocompatibilty.
```rs
#[arg(long, alias = "backend", value_enum, default_value_t = ReleaseGitForgeKind::Github)]
forge: ReleaseGitForgeKind,
```
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Closes https://github.com/release-plz/release-plz/issues/2144
