### PR TITLE
chore: Add a new changelog example that uses diff.rs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,5 @@ https://twitter.com/*
 https://x.com/*
 # When the changelog is committed, release-plz didn't create the tag yet
 https://github.com/release-plz/release-plz/compare/*
+# Certificate expired
+https://diff.rs

--- a/website/docs/changelog/examples.md
+++ b/website/docs/changelog/examples.md
@@ -521,7 +521,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```mdx-code-block
 # Changelog
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ## [1.0.1](https://github.com/orhun/git-cliff-readme-example/compare/v1.0.0...v1.0.1) - 2021-07-18

--- a/website/docs/changelog/examples.md
+++ b/website/docs/changelog/examples.md
@@ -414,10 +414,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 </details>
 
-## Visualizing changes
+## Source changes
 
-The changelog could also be configured to link changes
-from the new release to the previous one on diff.rs
+This configuration links source code changes
+from the new release to the previous one on
+[diff.rs](https://diff.rs/).
 
 <details>
   <summary>TOML configuration</summary>

--- a/website/docs/changelog/examples.md
+++ b/website/docs/changelog/examples.md
@@ -413,3 +413,129 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```
 
 </details>
+
+## Visualizing changes
+
+The changelog could also be configured to link changes
+from the new release to the previous one on diff.rs
+
+<details>
+  <summary>TOML configuration</summary>
+
+```toml
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
+
+body = """
+
+## [{{ version | trim_start_matches(pat="v") }}]\
+    {%- if release_link -%}\
+        ({{ release_link }})\
+    {% endif %} \
+    - {{ timestamp | date(format="%Y-%m-%d") }}
+
+    {% if previous.version -%}\
+        [View diff on diff.rs](https://diff.rs/{{ package }}/{{ previous.version }}/{{ package }}/{{ version }}/Cargo.toml)
+    {%- endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+    {% for commit in commits %}
+        {%- if commit.scope -%}
+            - *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}\
+                {{ commit.message }}\
+                {%- if commit.links %} \
+                    ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%})\
+                {% endif %}
+        {% else -%}
+            - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+        {% endif -%}
+    {% endfor -%}
+{% endfor %}
+"""
+
+commit_parsers = [
+  { message = "^feat", group = "added" },
+  { message = "^changed", group = "changed" },
+  { message = "^deprecated", group = "deprecated" },
+  { message = "^fix", group = "fixed" },
+  { message = "^security", group = "security" },
+  { message = "^.*", group = "other" },
+]
+```
+
+</details>
+
+<details>
+  <summary>Raw Output</summary>
+
+```md
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/orhun/git-cliff-readme-example/compare/v1.0.0...v1.0.1) - 2021-07-18
+
+[View diff on diff.rs](https://diff.rs/my_crate/1.0.0/my_crate/1.0.1/Cargo.toml)
+
+### Added
+
+- Add release script
+
+### Changed
+
+- Expose string functions
+
+## [1.0.0] - 2021-07-18
+
+### Added
+
+- Add README.md
+- Add ability to parse arrays
+- Add tested usage example
+
+### Fixed
+
+- Rename help argument due to conflict
+```
+
+</details>
+
+<details>
+  <summary>Rendered Output</summary>
+
+```mdx-code-block
+# Changelog
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+## [1.0.1](https://github.com/orhun/git-cliff-readme-example/compare/v1.0.0...v1.0.1) - 2021-07-18
+[View diff on diff.rs](https://diff.rs/my_crate/1.0.0/my_crate/1.0.1/Cargo.toml)
+### Added
+- Add release script
+### Changed
+- Expose string functions
+## [1.0.0] - 2021-07-18
+### Added
+- Add README.md
+- Add ability to parse arrays
+- Add tested usage example
+### Fixed
+- Rename help argument due to conflict
+```
+
+</details>

--- a/website/docs/changelog/examples.md
+++ b/website/docs/changelog/examples.md
@@ -521,7 +521,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```mdx-code-block
 # Changelog
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ## [1.0.1](https://github.com/orhun/git-cliff-readme-example/compare/v1.0.0...v1.0.1) - 2021-07-18


### PR DESCRIPTION
<!-- Please explain the changes you made -->
I added a new example on how to configure release-plz changelog to link to diff.rs showing changes between crate versions

Closes #2097 
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
