### PR TITLE
chore(changelog): stop trimming initial `v` in version

### DIFF
--- a/crates/release_plz/tests/all/changelog.rs
+++ b/crates/release_plz/tests/all/changelog.rs
@@ -185,7 +185,7 @@ async fn can_generate_single_changelog_for_multiple_packages_in_pr() {
     [changelog]
     body = """
 
-    ## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}](https://github.com/me/my-proj/{% if previous.version %}compare/{{ package }}-v{{ previous.version }}...{{ package }}-v{{ version }}{% else %}releases/tag/{{ package }}-v{{ version }}{% endif %})
+    ## `{{ package }}` - [{{ version }}](https://github.com/me/my-proj/{% if previous.version %}compare/{{ package }}-v{{ previous.version }}...{{ package }}-v{{ version }}{% else %}releases/tag/{{ package }}-v{{ version }}{% endif %})
     {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
     {% for commit in commits %}
@@ -245,7 +245,7 @@ async fn can_generate_single_changelog_for_multiple_packages_locally() {
     [changelog]
     body = """
 
-    ## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}](https://github.com/me/my-proj/{% if previous.version %}compare/{{ package }}-v{{ previous.version }}...{{ package }}-v{{ version }}{% else %}releases/tag/{{ package }}-v{{ version }}{% endif %})
+    ## `{{ package }}` - [{{ version }}](https://github.com/me/my-proj/{% if previous.version %}compare/{{ package }}-v{{ previous.version }}...{{ package }}-v{{ version }}{% else %}releases/tag/{{ package }}-v{{ version }}{% endif %})
     {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
     {% for commit in commits %}

--- a/crates/release_plz_core/src/changelog.rs
+++ b/crates/release_plz_core/src/changelog.rs
@@ -413,7 +413,7 @@ fn default_changelog_config(header: Option<String>) -> ChangelogConfig {
 
 fn default_changelog_body_config() -> &'static str {
     r#"
-## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 

--- a/website/docs/changelog/examples.md
+++ b/website/docs/changelog/examples.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 body = """
 
-## [{{ version | trim_start_matches(pat="v") }}]\
+## [{{ version }}]\
     {%- if release_link -%}\
         ({{ release_link }})\
     {% endif %} \
@@ -170,9 +170,9 @@ body = """
 
 {% if version %}\
     {% if previous.version %}\
-        ## [{{ version | trim_start_matches(pat="v") }}]({{ release_link }})
+        ## [{{ version }}]({{ release_link }})
     {% else %}\
-        ## [{{ version | trim_start_matches(pat="v") }}]
+        ## [{{ version }}]
     {% endif %}\
 {% endif %}\
 
@@ -298,7 +298,7 @@ GitHub/Gitea/GitLab username of the contributors.
 [changelog]
 body = """
 
-## [{{ version | trim_start_matches(pat="v") }}]\
+## [{{ version }}]\
     {%- if release_link -%}\
         ({{ release_link }})\
     {% endif %} \
@@ -437,7 +437,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 body = """
 
-## [{{ version | trim_start_matches(pat="v") }}]\
+## [{{ version }}]\
     {%- if release_link -%}\
         ({{ release_link }})\
     {% endif %} \

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -892,7 +892,7 @@ Default:
 ```toml
 [changelog]
 body = """
-## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}

--- a/website/docs/extra/single-changelog.md
+++ b/website/docs/extra/single-changelog.md
@@ -37,7 +37,7 @@ changelog_path = "./CHANGELOG.md"
 [changelog]
 body = """
 
-## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## `{{ package }}` - [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Release-plz never sets the `v` so it's useless to remove it.