### PR TITLE
fix: align registry env var name generation with Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "cargo_metadata",
  "dirs 6.0.0",
  "dunce",
+ "expect-test",
  "fs-err",
  "secrecy 0.10.3",
  "semver",

--- a/crates/cargo_utils/Cargo.toml
+++ b/crates/cargo_utils/Cargo.toml
@@ -23,3 +23,6 @@ semver.workspace = true
 url.workspace = true
 serde.workspace = true
 secrecy.workspace = true
+
+[dev-dependencies]
+expect-test.workspace = true

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -10,7 +10,9 @@ const CRATES_IO_REGISTRY: &str = "crates-io";
 /// Read index for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
-    let Ok(env_var) = get_registry_env_var_name(registry) else { return None };
+    let Ok(env_var) = get_registry_env_var_name(registry) else {
+        return None;
+    };
     std::env::var(env_var).ok()
 }
 

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -10,10 +10,7 @@ const CRATES_IO_REGISTRY: &str = "crates-io";
 /// Read index for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
-    let env_var = match get_registry_env_var_name(registry) {
-        Ok(env_var) => env_var,
-        Err(_) => return None,
-    };
+    let Ok(env_var) = get_registry_env_var_name(registry) else { return None };
     std::env::var(env_var).ok()
 }
 

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -33,7 +33,7 @@ fn get_registry_env_var_name(registry: &str) -> anyhow::Result<String> {
         } else if ch == '-' {
             sanitized_name.push('_');
         } else {
-            anyhow::bail!("Invalid character in registry name: '{}'", ch);
+            anyhow::bail!("Invalid character in registry name: '{ch}'");
         }
     }
 

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -10,7 +10,26 @@ const CRATES_IO_REGISTRY: &str = "crates-io";
 /// Read index for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
-    let env_var = format!("CARGO_REGISTRIES_{}_INDEX", registry.to_uppercase());
+    let mut sanitized_name = String::new();
+    let mut last_char_was_separator = false;
+
+    for ch in registry.chars() {
+        if ch.is_alphanumeric() {
+            // Append alphanumeric characters directly
+            sanitized_name.push(ch);
+            last_char_was_separator = false;
+        } else {
+            // If it's not alphanumeric, and the last char wasn't already a separator,
+            // append a single underscore.
+            if !last_char_was_separator {
+                sanitized_name.push('_');
+                last_char_was_separator = true;
+            }
+        }
+    }
+
+    let final_sanitized_name = sanitized_name.to_uppercase();
+    let env_var = format!("CARGO_REGISTRIES_{final_sanitized_name}_INDEX");
 
     std::env::var(env_var).ok()
 }

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -10,9 +10,7 @@ const CRATES_IO_REGISTRY: &str = "crates-io";
 /// Read index for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
-    let sanitized_name = sanitize_registry_name(registry);
-    let env_var = format!("CARGO_REGISTRIES_{sanitized_name}_INDEX");
-
+    let env_var = get_registry_env_var_name(registry);
     std::env::var(env_var).ok()
 }
 
@@ -21,7 +19,7 @@ pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
 /// - Alphanumeric characters are preserved.
 /// - Non-alphanumeric characters are replaced with underscores.
 /// - Consecutive non-alphanumeric characters are collapsed into a single underscore.
-fn sanitize_registry_name(registry: &str) -> String {
+fn get_registry_env_var_name(registry: &str) -> String {
     let mut sanitized_name = String::new();
     let mut last_char_was_separator = false;
 
@@ -40,7 +38,8 @@ fn sanitize_registry_name(registry: &str) -> String {
         }
     }
 
-    sanitized_name.to_uppercase()
+    let sanitized_name = sanitized_name.to_uppercase();
+    format!("CARGO_REGISTRIES_{sanitized_name}_INDEX")
 }
 
 /// Find the URL of a registry

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -173,7 +173,6 @@ pub fn cargo_home() -> anyhow::Result<PathBuf> {
     Ok(cargo_home)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -172,3 +172,37 @@ pub fn cargo_home() -> anyhow::Result<PathBuf> {
         .unwrap_or(default_cargo_home);
     Ok(cargo_home)
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_registry_env_var_name() {
+        assert_eq!(
+            get_registry_env_var_name("my-registry"),
+            "CARGO_REGISTRIES_MY_REGISTRY_INDEX"
+        );
+        assert_eq!(
+            get_registry_env_var_name("my_registry"),
+            "CARGO_REGISTRIES_MY_REGISTRY_INDEX"
+        );
+        assert_eq!(
+            get_registry_env_var_name("registry1"),
+            "CARGO_REGISTRIES_REGISTRY1_INDEX"
+        );
+        assert_eq!(
+            get_registry_env_var_name("UPPERCASE"),
+            "CARGO_REGISTRIES_UPPERCASE_INDEX"
+        );
+        assert_eq!(
+            get_registry_env_var_name("with-special-chars!@#$%^&*()"),
+            "CARGO_REGISTRIES_WITH_SPECIAL_CHARS__INDEX"
+        );
+        assert_eq!(
+            get_registry_env_var_name("multiple---separators"),
+            "CARGO_REGISTRIES_MULTIPLE_SEPARATORS_INDEX"
+        );
+    }
+}

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -10,6 +10,18 @@ const CRATES_IO_REGISTRY: &str = "crates-io";
 /// Read index for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
+    let sanitized_name = sanitize_registry_name(registry);
+    let env_var = format!("CARGO_REGISTRIES_{sanitized_name}_INDEX");
+
+    std::env::var(env_var).ok()
+}
+
+/// Sanitizes the registry name to construct a valid environment variable name.
+/// Mirrors Cargo's behavior:
+/// - Alphanumeric characters are preserved.
+/// - Non-alphanumeric characters are replaced with underscores.
+/// - Consecutive non-alphanumeric characters are collapsed into a single underscore.
+fn sanitize_registry_name(registry: &str) -> String {
     let mut sanitized_name = String::new();
     let mut last_char_was_separator = false;
 
@@ -28,10 +40,7 @@ pub fn registry_index_url_from_env(registry: &str) -> Option<String> {
         }
     }
 
-    let final_sanitized_name = sanitized_name.to_uppercase();
-    let env_var = format!("CARGO_REGISTRIES_{final_sanitized_name}_INDEX");
-
-    std::env::var(env_var).ok()
+    sanitized_name.to_uppercase()
 }
 
 /// Find the URL of a registry

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -21,9 +21,8 @@ pub fn registry_index_url_from_env(registry: &str) -> anyhow::Result<Option<Stri
 
 /// Sanitizes the registry name to construct a valid environment variable name.
 /// Mirrors Cargo's behavior:
-/// - Alphanumeric characters are preserved.
-/// - Hyphens (-) are converted to underscores (_).
-/// - Existing underscores (_) are preserved.
+/// - Alphanumeric characters and underscores (`_`) are preserved.
+/// - Hyphens (`-`) are converted to underscores (`_`).
 /// - Any other non-alphanumeric character is invalid and will cause an error.
 fn get_registry_env_var_name(registry: &str) -> anyhow::Result<String> {
     let mut sanitized_name = String::with_capacity(registry.len());
@@ -219,21 +218,19 @@ mod tests {
         // Invalid characters should fail
 
         expect_test::expect!["Invalid character in registry name: '!'"]
-        .assert_eq(&registry_env_var_name_error("with-special-chars!"));
+            .assert_eq(&registry_env_var_name_error("with-special-chars!"));
 
         expect_test::expect!["Invalid character in registry name: '+'"]
-        .assert_eq(&registry_env_var_name_error("invalid+char"));
+            .assert_eq(&registry_env_var_name_error("invalid+char"));
 
         expect_test::expect!["Invalid character in registry name: '@'"]
-        .assert_eq(&registry_env_var_name_error("has@symbol"));
+            .assert_eq(&registry_env_var_name_error("has@symbol"));
 
         expect_test::expect!["Invalid character in registry name: ' '"]
-        .assert_eq(&registry_env_var_name_error("space not allowed"));
+            .assert_eq(&registry_env_var_name_error("space not allowed"));
     }
 
     fn registry_env_var_name_error(registry: &str) -> String {
-        get_registry_env_var_name(registry)
-            .unwrap_err()
-            .to_string()
+        get_registry_env_var_name(registry).unwrap_err().to_string()
     }
 }


### PR DESCRIPTION
Ensures `registry_index_url_from_env` correctly forms environment variable names for Cargo registry configurations, even when registry names contain dashes.

The sanitization logic now mirrors Cargo's behavior:
1. Replace sequences of dashes with an underscore.
2. Any non-alphanumeric character that is not a dash or underscore is invalid.

This fixes a bug where names like `my-registry` would not resolve to the expected `CARGO_REGISTRIES_MY_REGISTRY_INDEX`.