### PR TITLE
chore: Indicate when diff calculation begins to avoid appearing stalled

### DIFF
--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -486,7 +486,10 @@ impl Updater<'_> {
         registry_packages: &PackagesCollection,
         repository: &Repo,
     ) -> anyhow::Result<Diff> {
-        info!("determining next version for {} {}", package.name, package.version);
+        info!(
+            "determining next version for {} {}",
+            package.name, package.version
+        );
         let package_path = get_package_path(package, repository, self.project.root())
             .context("failed to determine package path")?;
 

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -486,6 +486,7 @@ impl Updater<'_> {
         registry_packages: &PackagesCollection,
         repository: &Repo,
     ) -> anyhow::Result<Diff> {
+        info!("calculating diff for {} {}", package.name, package.version);
         let package_path = get_package_path(package, repository, self.project.root())
             .context("failed to determine package path")?;
 

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -486,7 +486,7 @@ impl Updater<'_> {
         registry_packages: &PackagesCollection,
         repository: &Repo,
     ) -> anyhow::Result<Diff> {
-        info!("calculating diff for {} {}", package.name, package.version);
+        info!("determining next version for {} {}", package.name, package.version);
         let package_path = get_package_path(package, repository, self.project.root())
             .context("failed to determine package path")?;
 


### PR DESCRIPTION
Previously, release-plz could appear unresponsive for a noticeable
period (e.g., 15 seconds on a reasonably sized repository) while
calculating the diff for a package. This change adds a log message at
the start of the diff calculation to inform the user about this
potentially long-running operation.

<img width="1632" alt="image" src="https://github.com/user-attachments/assets/6e14f921-6dcc-40d7-9f70-634fa4bb12c1" />
