### PR TITLE
add check-only & exit-status

### DIFF
--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -105,6 +105,8 @@ pub struct Update {
     /// Kind of git host where your project is hosted.
     #[arg(long, visible_alias = "backend", value_enum, default_value_t = GitForgeKind::Github)]
     forge: GitForgeKind,
+    #[arg(long)]
+    check_only: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
@@ -174,6 +176,7 @@ impl Update {
                 format!("Cannot find file {project_manifest:?}. Make sure you are inside a rust project or that --manifest-path points to a valid Cargo.toml file.")
             })?
             .with_dependencies_update(self.dependencies_update(config))
+            .with_check_only(self.check_only)
             .with_allow_dirty(self.allow_dirty(config));
         match self.get_repo_url(config) {
             Ok(repo_url) => {
@@ -308,6 +311,7 @@ mod tests {
             config: None,
             forge: GitForgeKind::Github,
             git_token: None,
+            check_only: false,
         };
         let config: Config = toml::from_str("").unwrap();
         let req = update_args

--- a/crates/release_plz_core/src/command/update/update_request.rs
+++ b/crates/release_plz_core/src/command/update/update_request.rs
@@ -45,6 +45,8 @@ pub struct UpdateRequest {
     /// Prepare release only if at least one commit respects a regex.
     release_commits: Option<Regex>,
     git: Option<GitForge>,
+    /// Do not write any manifests simply check for the next version.
+    check_only: bool,
 }
 
 impl UpdateRequest {
@@ -64,6 +66,7 @@ impl UpdateRequest {
             packages_config: PackagesConfig::default(),
             release_commits: None,
             git: None,
+            check_only: false,
         })
     }
 
@@ -119,6 +122,14 @@ impl UpdateRequest {
             changelog_req,
             ..self
         }
+    }
+
+    pub fn with_check_only(self, check_only: bool) -> Self {
+        Self { check_only, ..self }
+    }
+
+    pub fn check_only(&self) -> bool {
+        self.check_only
     }
 
     /// Set update config for all packages.


### PR DESCRIPTION
* adds a `check-only` flag to the `update` command which does not update the manifests and simply outputs the summary.
* adds a `exit-status` flag to the `update` command which returns a exit code of `1` when there are updates to be done.