### PR TITLE
fix: More generous retry for failed HTTP/2 registry request

### DIFF
--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -132,7 +132,7 @@ async fn fetch_sparse_metadata(
     let mut res = request_for_sparse_metadata(index, crate_name, token, Version::HTTP_2).await;
     if let Err(ref e) = res {
         match e.downcast_ref::<reqwest::Error>() {
-            Some(e) if e.is_connect() => {
+            Some(e) if !e.is_status() => {
                 debug!("HTTP/2 sparse index request failed, trying HTTP/1.1");
                 res = request_for_sparse_metadata(index, crate_name, token, Version::HTTP_11).await;
             }


### PR DESCRIPTION
With some private registries that do not support HTTP/2, or perhaps falsely advertise as supporting it, reqwest does not always identify the cause of failure as a connection error. To work around this, make our retry with HTTP/1.1 more generous by retrying any error that is not clearly caused by a status code returned by the server.

Related to https://github.com/release-plz/release-plz/issues/1668.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
