### PR TITLE
fix: allow license-file in Cargo.toml

### DIFF
--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -185,8 +185,11 @@ impl Project {
         let mut missing_version_errors = Vec::new();
 
         for package in &self.publishable_packages() {
-            if package.license.is_none() {
-                missing_fields.push(format!("- `license` for package `{}`", package.name));
+            if package.license.is_none() && package.license_file.is_none() {
+                missing_fields.push(format!(
+                    "- `license` or `license-file` for package `{}`",
+                    package.name
+                ));
             }
             if package.description.is_none() {
                 missing_fields.push(format!("- `description` for package `{}`", package.name));
@@ -412,6 +415,15 @@ mod tests {
             result.unwrap_err().to_string(),
             "The following overrides are not present in the workspace: `typo_tesst`. Check for typos"
         );
+    }
+
+    #[test]
+    fn test_license_file() {
+        let local_manifest = Utf8Path::new("../../tests/fixtures/non-standard-license/Cargo.toml");
+        let project = get_project(local_manifest, None, &HashSet::default(), true, None, None)
+            .expect("Should be ok");
+        let result = project.check_mandatory_fields();
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/tests/fixtures/non-standard-license/Cargo.toml
+++ b/tests/fixtures/non-standard-license/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "license-file-test"
+version = "0.1.0"
+edition = "2024"
+description = "Use license file"
+license-file = "license.txt"
+
+[workspace]
+
+[[bin]]
+name = "license-file-test"
+path = "src/main.rs"


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Close: #2286 
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
