### PR TITLE
fix: Retry HTTP/2 GOAWAY from registry with HTTP/1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,6 +4859,7 @@ dependencies = [
  "git-cliff-core",
  "git-url-parse",
  "git_cmd",
+ "h2",
  "http",
  "ignore",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fs-err = "3.0.0"
 git-cliff-core = { version = "2.7.0", default-features = false }
 git-conventional = "0.12.9"
 git-url-parse = "0.4.5"
+h2 = "0.4"
 http = "1.2.0"
 ignore = "0.4.23"
 itertools = "0.14.0"

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -31,6 +31,7 @@ dunce.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
 git-cliff-core.workspace = true
 git-url-parse.workspace = true
+h2.workspace = true
 ignore.workspace = true
 itertools.workspace = true
 parse-changelog.workspace = true


### PR DESCRIPTION
With some private registries that do not support HTTP/2, or perhaps falsely advertise as supporting it, reqwest does not always identify the cause of failure as a connection error. In this case, the underlying `h2` library may return a premature `GOAWAY` error from either the client or server. If this happens, we should use HTTP/1.1 instead.

This PR implements this by walking up the chain of errors to see if a "go away" error is a cause. This is a fairly explicit check, but the downside is that we have to add `h2` as a direct dependency in order to pull in the `h2::Error` type. (It is already a transitive dependency through `reqwest`.)

Related to #1668 and #2261.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
