### PR TITLE
feat: add a fallback index to attempt the legacy hash if the primary index fails

### DIFF
--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -17,6 +17,8 @@ pub struct CargoRegistry {
     /// [`Option::None`] means default 'crate.io'.
     pub name: Option<String>,
     pub index: CargoIndex,
+    /// A fallback registry index to try if the primary `index` fails.
+    pub fallback_index: Option<CargoIndex>,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/release_plz_core/src/cargo_hash_kind.rs
+++ b/crates/release_plz_core/src/cargo_hash_kind.rs
@@ -33,6 +33,7 @@ pub fn try_get_fallback_hash_kind(
     use crates_index::HashKind;
 
     match hash_kind {
+        // Some registries still use the legacy hash kind, so we fallback to it.
         HashKind::Stable => Some(HashKind::Legacy),
         HashKind::Legacy => None,
     }

--- a/crates/release_plz_core/src/cargo_hash_kind.rs
+++ b/crates/release_plz_core/src/cargo_hash_kind.rs
@@ -95,16 +95,12 @@ mod tests {
     fn test_registry_fallback() {
         use crates_index::HashKind;
 
-        for (stdout, _expected_fallback_hash_kind) in [
-            (
-                "cargo 1.85.0 (d73d2caf9 2024-12-31)",
-                Some(HashKind::Stable),
-            ),
-            ("cargo 1.84.0 (abc12345 2024-01-01)", None),
-        ] {
-            let hash_kind = get_hash_kind_from_stdout(stdout);
-            let fallback_hash_kind = try_get_fallback_hash_kind(&hash_kind);
-            assert!(matches!(fallback_hash_kind, _expected_fallback_hash_kind));
-        }
+        let hash_kind = get_hash_kind_from_stdout("cargo 1.85.0 (d73d2caf9 2024-12-31)");
+        let fallback_hash_kind = try_get_fallback_hash_kind(&hash_kind);
+        assert!(matches!(fallback_hash_kind, Some(HashKind::Legacy)));
+
+        let hash_kind = get_hash_kind_from_stdout("cargo 1.84.0 (1234abcde 2024-12-31)");
+        let fallback_hash_kind = try_get_fallback_hash_kind(&hash_kind);
+        assert!(fallback_hash_kind.is_none());
     }
 }

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -679,8 +679,8 @@ async fn is_package_published(
     // DEVNOTE: the following vars will default to the primary index but
     // may be updated to a fallback index if the primary index returns an
     // error.
-    let mut pkg_is_published = is_published_primary;
-    let mut index = primary_index;
+    let pkg_is_published = is_published_primary;
+    let index = primary_index;
     // If a fallback index is defined.
     if let Some(mut fallback_index) = fallback_index {
         // and if the primary index returns an error, attempt to check the
@@ -688,9 +688,8 @@ async fn is_package_published(
         if pkg_is_published.is_err() {
             let fallback_is_published =
                 is_published(&mut fallback_index, package, input.publish_timeout, token).await;
-            if fallback_is_published.is_ok() {
-                pkg_is_published = fallback_is_published;
-                index = fallback_index;
+            if let Ok(fallback_is_published) = fallback_is_published {
+                return Ok((fallback_is_published, fallback_index));
             }
         };
     };

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -672,7 +672,7 @@ async fn is_package_published(
     mut primary_index: CargoIndex,
     fallback_index: Option<CargoIndex>,
     token: &Option<secrecy::SecretBox<str>>,
-) -> (anyhow::Result<bool>, CargoIndex) {
+) -> anyhow::Result<(bool, CargoIndex)> {
     let is_published_primary =
         is_published(&mut primary_index, package, input.publish_timeout, token).await;
 
@@ -694,7 +694,7 @@ async fn is_package_published(
             }
         };
     };
-    (pkg_is_published, index)
+    Ok((pkg_is_published?, index))
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -642,9 +642,11 @@ async fn release_package_if_needed(
     {
         let token = input.find_registry_token(name.as_deref())?;
         let (pkg_is_published, mut index) =
-            is_package_published(input, package, primary_index, fallback_index, &token).await;
+            is_package_published(input, package, primary_index, fallback_index, &token)
+                .await
+                .context("can't determine if package is published")?;
 
-        if pkg_is_published.context("can't determine if package is published")? {
+        if pkg_is_published {
             info!("{} {}: already published", package.name, package.version);
             continue;
         }

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -686,7 +686,7 @@ async fn is_package_published(
 
     // If a fallback index is defined.
     if let Some(mut fallback_index) = fallback_index {
-        // and if the primary index returns an error, attempt to check the
+        // And if the primary index returns an error, attempt to check the
         // fallback.
         if is_published_primary.is_err() {
             let fallback_is_published =

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -677,7 +677,7 @@ async fn is_package_published(
     package: &Package,
     mut primary_index: CargoIndex,
     fallback_index: Option<CargoIndex>,
-    token: &Option<secrecy::SecretBox<str>>,
+    token: &Option<SecretString>,
 ) -> anyhow::Result<(bool, CargoIndex)> {
     let is_published_primary =
         is_published(&mut primary_index, package, input.publish_timeout, token).await;

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -644,7 +644,7 @@ async fn release_package_if_needed(
         let (pkg_is_published, mut index) =
             is_package_published(input, package, primary_index, fallback_index, &token)
                 .await
-                .context("can't determine if package is published")?;
+                .with_context(|| format!("can't determine if package {} is published", package.name))?;
 
         if pkg_is_published {
             info!("{} {}: already published", package.name, package.version);

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -779,7 +779,7 @@ fn registry_indexes(
 
     let mut registry_indexes = registry_urls
         .into_iter()
-        .map(|(registry, u)| get_cargo_registry(hash_kind, registry, u))
+        .map(|(registry, u)| get_cargo_registry(hash_kind, registry, &u))
         .collect::<anyhow::Result<Vec<CargoRegistry>>>()?;
     if registry_indexes.is_empty() {
         registry_indexes.push(CargoRegistry {
@@ -794,7 +794,7 @@ fn registry_indexes(
 fn get_cargo_registry(
     hash_kind: &crates_index::HashKind,
     registry: String,
-    u: Url,
+    u: &Url,
 ) -> anyhow::Result<CargoRegistry> {
     let fallback_hash = try_get_fallback_hash_kind(hash_kind);
 

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -670,6 +670,8 @@ async fn release_package_if_needed(
 
 /// Check if `package` is published in the primary index.
 /// If the check fails, check the fallback index if it exists.
+///
+/// Returns whether the package is published and the index used for the check.
 async fn is_package_published(
     input: &ReleaseRequest,
     package: &Package,

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -819,11 +819,11 @@ fn get_cargo_registry(
     };
 
     match (maybe_primary_index, maybe_fallback_index) {
-        (Ok(primary_index), None) => Ok((primary_index, None)),
+        // In cases where the primary index succeeds, the lookup should
+        // continue regardless of the state of the fallback index.
+        (Ok(primary_index), None) | (Ok(primary_index), Some(Err(_))) => Ok((primary_index, None)),
         (Ok(primary_index), Some(Ok(fallback_index))) => Ok((primary_index, Some(fallback_index))),
-        (Err(e), _) | (_, Some(Err(e))) => {
-            Err(anyhow::anyhow!("failed to get cargo registry: {e}"))
-        }
+        (Err(e), _) => Err(anyhow::anyhow!("failed to get cargo registry: {e}")),
     }
     .map(|(index, maybe_fallback_index)| CargoRegistry {
         name: Some(registry),

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -644,7 +644,9 @@ async fn release_package_if_needed(
         let (pkg_is_published, mut index) =
             is_package_published(input, package, primary_index, fallback_index, &token)
                 .await
-                .with_context(|| format!("can't determine if package {} is published", package.name))?;
+                .with_context(|| {
+                    format!("can't determine if package {} is published", package.name)
+                })?;
 
         if pkg_is_published {
             info!("{} {}: already published", package.name, package.version);


### PR DESCRIPTION
## General

This PR introduces a fallback index field to the `CargoRegistry` struct. This fallback index is the same index using the `HashKind::Legacy` hash kind if the cargo version is 1.85+. When releasing a crate, the cli will attempt the fallback index if the primary index fails.

relates to #2340 

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
