### PR TITLE
feat: use api to create branches

### DIFF
--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -304,7 +304,7 @@ async fn handle_opened_pr(
 }
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
-    if matches!(git_client.forge, ForgeType::Github) {
+    if git_client.forge == ForgeType::Github {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
         create_release_branch(repo, &pr.branch, &pr.title)?;
@@ -329,7 +329,7 @@ async fn update_pr(
             repository.original_branch()
         )
     })?;
-    if matches!(git_client.forge, ForgeType::Github) {
+    if git_client.forge == ForgeType::Github {
         github_force_push(git_client, opened_pr, repository).await?;
     } else {
         force_push(opened_pr, repository)?;

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -304,6 +304,7 @@ async fn handle_opened_pr(
 }
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
+    repo.checkout_new_branch(&pr.branch)?;
     if git_client.forge == ForgeType::Github {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
@@ -482,7 +483,6 @@ fn create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
-    repository.checkout_new_branch(release_branch)?;
     add_changes_and_commit(repository, commit_message)?;
     repository.push(release_branch)?;
     Ok(())

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -304,6 +304,8 @@ async fn handle_opened_pr(
 }
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
+    let sha = repo.current_commit_hash()?;
+    git_client.create_branch(&pr.branch, &sha).await?;
     if matches!(git_client.forge, ForgeType::Github) {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
@@ -494,8 +496,6 @@ async fn github_create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
-    let sha = repository.current_commit_hash()?;
-    client.create_branch(release_branch, &sha).await?;
     github_graphql::commit_changes(client, repository, commit_message, release_branch).await
 }
 

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -482,7 +482,7 @@ fn create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
-    repository.checkout_new_branch(&release_branch)?;
+    repository.checkout_new_branch(release_branch)?;
     add_changes_and_commit(repository, commit_message)?;
     repository.push(release_branch)?;
     Ok(())
@@ -495,7 +495,7 @@ async fn github_create_release_branch(
     commit_message: &str,
 ) -> anyhow::Result<()> {
     let sha = repository.current_commit_hash()?;
-    client.create_branch(&release_branch, &sha).await?;
+    client.create_branch(release_branch, &sha).await?;
     github_graphql::commit_changes(client, repository, commit_message, release_branch).await
 }
 

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -304,12 +304,9 @@ async fn handle_opened_pr(
 }
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
-    let sha = repo.current_commit_hash()?;
-    git_client.create_branch(&pr.branch, &sha).await?;
     if matches!(git_client.forge, ForgeType::Github) {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
-        repo.checkout_new_branch(&pr.branch)?;
         create_release_branch(repo, &pr.branch, &pr.title)?;
     }
     debug!("changes committed to release branch {}", pr.branch);
@@ -485,6 +482,7 @@ fn create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
+    repository.checkout_new_branch(&release_branch)?;
     add_changes_and_commit(repository, commit_message)?;
     repository.push(release_branch)?;
     Ok(())
@@ -496,6 +494,8 @@ async fn github_create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
+    let sha = repository.current_commit_hash()?;
+    client.create_branch(&release_branch, &sha).await?;
     github_graphql::commit_changes(client, repository, commit_message, release_branch).await
 }
 

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -304,10 +304,10 @@ async fn handle_opened_pr(
 }
 
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
-    repo.checkout_new_branch(&pr.branch)?;
     if matches!(git_client.forge, ForgeType::Github) {
         github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
     } else {
+        repo.checkout_new_branch(&pr.branch)?;
         create_release_branch(repo, &pr.branch, &pr.title)?;
     }
     debug!("changes committed to release branch {}", pr.branch);
@@ -494,7 +494,8 @@ async fn github_create_release_branch(
     release_branch: &str,
     commit_message: &str,
 ) -> anyhow::Result<()> {
-    repository.push(release_branch)?;
+    let sha = repository.current_commit_hash()?;
+    client.create_branch(release_branch, &sha).await?;
     github_graphql::commit_changes(client, repository, commit_message, release_branch).await
 }
 

--- a/crates/release_plz_core/src/git/forge.rs
+++ b/crates/release_plz_core/src/git/forge.rs
@@ -902,6 +902,63 @@ impl GitClient {
         };
         format!("{}/{commits_api_path}{commit}", self.repo_url())
     }
+
+    /// Create a new branch from the given SHA.
+    pub async fn create_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+        match self.forge {
+            ForgeType::Github => {
+                self.post_github_ref(&format!("refs/heads/{branch_name}"), sha)
+                    .await
+            }
+            ForgeType::Gitlab => self.post_gitlab_branch(branch_name, sha).await,
+            ForgeType::Gitea => self.post_gitea_branch(branch_name, sha).await,
+        }
+    }
+
+    async fn post_github_ref(&self, ref_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+        self.client
+            .post(format!("{}/git/refs", self.repo_url()))
+            .json(&json!({
+                "ref": ref_name,
+                "sha": sha
+            }))
+            .send()
+            .await?
+            .successful_status()
+            .await
+            .context("failed to create branch")?;
+        Ok(())
+    }
+
+    async fn post_gitlab_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+        self.client
+            .post(format!("{}/repository/branches", self.repo_url()))
+            .json(&json!({
+                "branch": branch_name,
+                "ref": sha
+            }))
+            .send()
+            .await?
+            .successful_status()
+            .await
+            .context("failed to create branch")?;
+        Ok(())
+    }
+
+    async fn post_gitea_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+        self.client
+            .post(format!("{}/branches", self.repo_url()))
+            .json(&json!({
+                "new_branch_name": branch_name,
+                "old_ref_name": sha
+            }))
+            .send()
+            .await?
+            .successful_status()
+            .await
+            .context("failed to create branch")?;
+        Ok(())
+    }
 }
 
 pub fn validate_labels(labels: &[String]) -> anyhow::Result<()> {

--- a/crates/release_plz_core/src/git/forge.rs
+++ b/crates/release_plz_core/src/git/forge.rs
@@ -904,7 +904,7 @@ impl GitClient {
     }
 
     /// Create a new branch from the given SHA.
-    pub async fn create_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+    pub async fn create_branch(&self, branch_name: &str, sha: &str) -> anyhow::Result<()> {
         match self.forge {
             ForgeType::Github => {
                 self.post_github_ref(&format!("refs/heads/{branch_name}"), sha)
@@ -915,7 +915,7 @@ impl GitClient {
         }
     }
 
-    async fn post_github_ref(&self, ref_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+    async fn post_github_ref(&self, ref_name: &str, sha: &str) -> anyhow::Result<()> {
         self.client
             .post(format!("{}/git/refs", self.repo_url()))
             .json(&json!({
@@ -930,7 +930,7 @@ impl GitClient {
         Ok(())
     }
 
-    async fn post_gitlab_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+    async fn post_gitlab_branch(&self, branch_name: &str, sha: &str) -> anyhow::Result<()> {
         self.client
             .post(format!("{}/repository/branches", self.repo_url()))
             .json(&json!({
@@ -945,7 +945,7 @@ impl GitClient {
         Ok(())
     }
 
-    async fn post_gitea_branch(&self, branch_name: &str, sha: &str) -> Result<(), anyhow::Error> {
+    async fn post_gitea_branch(&self, branch_name: &str, sha: &str) -> anyhow::Result<()> {
         self.client
             .post(format!("{}/branches", self.repo_url()))
             .json(&json!({


### PR DESCRIPTION
<!-- Please explain the changes you made -->

As in https://github.com/release-plz/release-plz/issues/2354, use the API to create a new branch on the remote instead of the local Git CLI.

Currently, the implementations for Gitea/GitLab seem useless, but I'll migrate commits to Gitea/GitLab, as well as GitHub, so we can merge the implementation.

ref:
- https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference
- https://docs.gitlab.com/api/branches/#create-repository-branch
- https://gitea.com/api/swagger#/repository/repoCreateBranch

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
