### PR TITLE
feat: use api to delete branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4786,6 +4786,7 @@ dependencies = [
  "toml_edit 0.23.4",
  "tracing",
  "url",
+ "urlencoding",
  "walkdir",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tracing = "0.1.41"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
+urlencoding = "2.1.3"
 walkdir = "2.5.0"
 wiremock = "0.6.2"
 

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -54,6 +54,7 @@ strip-ansi-escapes.workspace = true
 tokio = { workspace = true, features = ["fs", "macros"] }
 tera.workspace = true
 http.workspace = true
+urlencoding.workspace = true
 
 [dev-dependencies]
 git_cmd = { path = "../git_cmd", features = ["test_fixture"] }

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -234,7 +234,7 @@ async fn open_or_update_release_pr(
             )
             .await
         }
-        None => create_pr(&git_client, repo, &new_pr).await,
+        None => create_pr(git_client, repo, &new_pr).await,
     }?;
     let release_pr = ReleasePr {
         releases: packages_to_update
@@ -286,7 +286,7 @@ async fn handle_opened_pr(
                     .close_pr(opened_pr.number)
                     .await
                     .context("cannot close old release-plz prs")?;
-                create_pr(&git_client, repo, new_pr).await?
+                create_pr(git_client, repo, new_pr).await?
             }
         }
     } else {
@@ -299,7 +299,7 @@ async fn handle_opened_pr(
             .close_pr(opened_pr.number)
             .await
             .context("cannot close old release-plz prs")?;
-        create_pr(&git_client, repo, new_pr).await?
+        create_pr(git_client, repo, new_pr).await?
     })
 }
 
@@ -436,7 +436,7 @@ async fn github_force_push(
         // - If we revert the last commit of the release PR branch, GitHub will close the release PR
         //   because the branch is the same as the default branch. So we can't revert the latest release-plz commit and push the new one.
         // To learn more, see https://github.com/release-plz/release-plz/issues/1487
-        github_create_release_branch(&client, repository, &tmp_release_branch, &pr.title).await?;
+        github_create_release_branch(client, repository, &tmp_release_branch, &pr.title).await?;
 
         repository.fetch(&tmp_release_branch)?;
 

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -482,7 +482,7 @@ impl Drop for TmpBranch {
         let name = self.name.clone();
         tokio::spawn(async move {
             if let Err(e) = client.delete_branch(&name).await {
-                tracing::error!("cannot delete branch {}: {:?}", name, e);
+                tracing::error!("cannot delete branch {name}: {e:?}");
             }
         });
     }

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -426,66 +426,39 @@ async fn github_force_push(
     repository: &Repo,
 ) -> anyhow::Result<()> {
     // Create a temporary branch.
-    let tmp_release_branch = {
-        let name = format!("{}-tmp-{}", pr.branch(), rand::random::<u32>());
-        TmpBranch::checkout_new(repository, name, client.clone())
-    }?;
+    let tmp_release_branch = format!("{}-tmp-{}", pr.branch(), rand::random::<u32>());
+    repository.checkout_new_branch(&tmp_release_branch)?;
 
-    // Push the "Verified" commit in the temporary branch using
-    // the GitHub API.
-    // We push the release-plz changes to the temporary branch instead of the release PR branch because:
-    // - You can't force-push with the GitHub API, so we can't commit to the release PR branch
-    //   directly if we want a "Verified" commit.
-    // - If we revert the last commit of the release PR branch, GitHub will close the release PR
-    //   because the branch is the same as the default branch. So we can't revert the latest release-plz commit and push the new one.
-    // To learn more, see https://github.com/release-plz/release-plz/issues/1487
-    github_create_release_branch(&client, repository, &tmp_release_branch.name, &pr.title).await?;
+    let run = async {
+        // Push the "Verified" commit in the temporary branch using
+        // the GitHub API.
+        // We push the release-plz changes to the temporary branch instead of the release PR branch because:
+        // - You can't force-push with the GitHub API, so we can't commit to the release PR branch
+        //   directly if we want a "Verified" commit.
+        // - If we revert the last commit of the release PR branch, GitHub will close the release PR
+        //   because the branch is the same as the default branch. So we can't revert the latest release-plz commit and push the new one.
+        // To learn more, see https://github.com/release-plz/release-plz/issues/1487
+        github_create_release_branch(&client, repository, &tmp_release_branch, &pr.title).await?;
 
-    repository.fetch(&tmp_release_branch.name)?;
+        repository.fetch(&tmp_release_branch)?;
 
-    // Rewrite the PR branch so that it's the same as the temporary branch.
-    repository.force_push(&format!(
-        "{}/{}:{}",
-        repository.original_remote(),
-        tmp_release_branch.name,
-        pr.branch()
-    ))?;
+        // Rewrite the PR branch so that it's the same as the temporary branch.
+        repository.force_push(&format!(
+            "{}/{}:{}",
+            repository.original_remote(),
+            tmp_release_branch,
+            pr.branch()
+        ))?;
+        Ok::<(), anyhow::Error>(())
+    };
 
-    // The temporary branch is deleted in remote when it goes out of scope.
-    Ok(())
-}
+    let result = run.await;
 
-/// Temporary branch.
-/// It deletes the branch in remote when it goes out of scope.
-/// In this way, we can ensure that the branch is deleted even if the program panics.
-struct TmpBranch {
-    name: String,
-    client: Arc<GitClient>,
-}
-
-impl TmpBranch {
-    fn checkout_new(
-        repository: &Repo,
-        name: impl Into<String>,
-        client: Arc<GitClient>,
-    ) -> anyhow::Result<Self> {
-        let name = name.into();
-        repository.checkout_new_branch(&name)?;
-        let branch = Self { name, client };
-        Ok(branch)
+    if let Err(e) = client.delete_branch(&tmp_release_branch).await {
+        tracing::error!("cannot delete branch {tmp_release_branch}: {e:?}");
     }
-}
 
-impl Drop for TmpBranch {
-    fn drop(&mut self) {
-        let client = self.client.clone();
-        let name = self.name.clone();
-        tokio::spawn(async move {
-            if let Err(e) = client.delete_branch(&name).await {
-                tracing::error!("cannot delete branch {name}: {e:?}");
-            }
-        });
-    }
+    result
 }
 
 fn create_release_branch(

--- a/crates/release_plz_core/src/git/forge.rs
+++ b/crates/release_plz_core/src/git/forge.rs
@@ -904,7 +904,7 @@ impl GitClient {
     }
 
     /// Delete a branch.
-    pub async fn delete_branch(&self, branch_name: &str) -> Result<(), anyhow::Error> {
+    pub async fn delete_branch(&self, branch_name: &str) -> anyhow::Result<()> {
         let url = match self.forge {
             ForgeType::Github => format!("{}/git/refs/heads/{}", self.repo_url(), branch_name),
             ForgeType::Gitlab => format!(

--- a/crates/release_plz_core/src/git/forge.rs
+++ b/crates/release_plz_core/src/git/forge.rs
@@ -902,6 +902,31 @@ impl GitClient {
         };
         format!("{}/{commits_api_path}{commit}", self.repo_url())
     }
+
+    /// Delete a branch.
+    pub async fn delete_branch(&self, branch_name: &str) -> Result<(), anyhow::Error> {
+        let url = match self.forge {
+            ForgeType::Github => format!("{}/git/refs/heads/{}", self.repo_url(), branch_name),
+            ForgeType::Gitlab => format!(
+                "{}/repository/branches/{}",
+                self.repo_url(),
+                urlencoding::encode(branch_name)
+            ),
+            ForgeType::Gitea => format!(
+                "{}/branches/{}",
+                self.repo_url(),
+                urlencoding::encode(branch_name)
+            ),
+        };
+        self.client
+            .delete(url)
+            .send()
+            .await?
+            .successful_status()
+            .await
+            .context("failed to delete branch")?;
+        Ok(())
+    }
 }
 
 pub fn validate_labels(labels: &[String]) -> anyhow::Result<()> {

--- a/crates/release_plz_core/src/repo_url.rs
+++ b/crates/release_plz_core/src/repo_url.rs
@@ -83,11 +83,7 @@ impl RepoUrl {
 
     pub fn gitlab_api_url(&self) -> String {
         let v4 = "api/v4/projects";
-        let prj_path = self
-            .path
-            .strip_prefix('/')
-            .unwrap_or(&self.path)
-            .replace('/', "%2F");
+        let prj_path = urlencoding::encode(self.path.strip_prefix('/').unwrap_or(&self.path));
         let scheme = if self.scheme == "ssh" {
             "https"
         } else {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

As in https://github.com/release-plz/release-plz/issues/2354, use the API to delete a new branch on the remote instead of the local Git CLI.

ref:
- https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#delete-a-reference
- https://docs.gitlab.com/api/branches/#delete-repository-branch
- https://gitea.com/api/swagger#/repository/repoDeleteBranch

I added `urlencoding` crate to encode branch names for GitLab/Gitea, but if it's better to stick to replacing `/` with `%2F`, I'll refactor so.

Also, since `Drop` trait doesn't support `async`, it looks messy. I think we can remove `TmpBranch` and manually handle the cleanup.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
