### PR TITLE
fix: include dev-dependencies in topological release order

### DIFF
--- a/crates/fake_package/src/dependency.rs
+++ b/crates/fake_package/src/dependency.rs
@@ -4,6 +4,7 @@ use cargo_metadata::{Dependency, DependencyKind};
 pub struct FakeDependency {
     name: String,
     kind: DependencyKind,
+    req: String,
 }
 
 impl FakeDependency {
@@ -11,6 +12,7 @@ impl FakeDependency {
         Self {
             name: name.into(),
             kind: DependencyKind::Normal,
+            req: "0.1.0".to_string(),
         }
     }
 
@@ -20,13 +22,23 @@ impl FakeDependency {
             ..self
         }
     }
+
+    /// Create a dev-dependency without a version requirement (path-only).
+    /// These are stripped from the published manifest by cargo.
+    pub fn unversioned_dev(self) -> Self {
+        Self {
+            kind: DependencyKind::Development,
+            req: "*".to_string(),
+            ..self
+        }
+    }
 }
 
 impl From<FakeDependency> for Dependency {
     fn from(dep: FakeDependency) -> Self {
         serde_json::from_value(serde_json::json!({
             "name": dep.name,
-            "req": "0.1.0",
+            "req": dep.req,
             "kind": dep.kind,
             "optional": false,
             "uses_default_features": true,

--- a/crates/release_plz_core/src/release_order.rs
+++ b/crates/release_plz_core/src/release_order.rs
@@ -36,7 +36,7 @@ fn release_order_inner<'a>(
             d.name == *p.name
               // Exclude the current package.
               && p.name != pkg.name
-              && should_dep_be_released_before(d, pkg)
+              && should_dep_be_released_before(d)
         }) {
             anyhow::ensure!(
                 !is_package_in(dep, passed),
@@ -60,27 +60,21 @@ fn is_package_in(pkg: &Package, packages: &[&Package]) -> bool {
     packages.iter().any(|p| p.name == pkg.name)
 }
 
-/// Check if the dependency is enabled in features.
-fn is_dep_in_features(pkg: &Package, dep: &str) -> bool {
-    pkg.features
-        // Discard features name.
-        .values()
-        // Any feature contains the dependency in the format `dep/feature`.
-        .any(|enabled_features| {
-            enabled_features
-                .iter()
-                .filter_map(|feature| feature.split_once('/').map(|split| split.0))
-                .any(|enabled_dependency| enabled_dependency == dep)
-        })
-}
-
 /// Check if the dependency should be released before the current package.
-fn should_dep_be_released_before(dep: &Dependency, pkg: &Package) -> bool {
-    // Ignore development dependencies. They don't need to be published before the current package...
-    matches!(dep.kind, DependencyKind::Normal | DependencyKind::Build)
-      // ...unless they are in features. In fact, `cargo-publish` compiles crates that are in features
-      // and dev-dependencies, even if they are not present in normal dependencies.
-      || is_dep_in_features(pkg, &dep.name)
+/// Normal and Build dependencies always affect release order.
+/// Dev-dependencies affect release order only if they have a version
+/// requirement specified — matching `cargo publish --workspace` behavior.
+/// Dev-deps without a version (`req == "*"`) are stripped from the published
+/// manifest, so they don't need to be published first.
+fn should_dep_be_released_before(dep: &Dependency) -> bool {
+    match dep.kind {
+        DependencyKind::Normal | DependencyKind::Build => true,
+        // Dev-deps with a version requirement remain in the published manifest
+        // and must be resolvable on the registry. Dev-deps without a version
+        // (req == "*") are stripped by cargo on publish, so they can be ignored.
+        DependencyKind::Development => !dep.req.comparators.is_empty(),
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -156,16 +150,32 @@ mod tests {
 
     /// ┌──┐
     /// │  ▼
-    /// A  B (dev dependency)
+    /// A  B (versioned dev dependency)
     /// ▲  │
     /// └──┘
+    /// Versioned dev-dep cycles are circular dependencies because
+    /// `cargo package` validates versioned dev-deps against the registry,
+    /// so neither package can be published first.
     #[test]
-    fn two_packages_dev_cycle_is_ok() {
+    fn two_packages_versioned_dev_cycle_is_detected() {
         let pkgs = [&pkg("a", &[dev_dep("b")]), &pkg("b", &[dep("a")])];
-        assert_eq!(order(&pkgs), ["a", "b"]);
+        expect_test::expect!["Circular dependency detected: a -> b"]
+            .assert_eq(&release_order(&pkgs).unwrap_err().to_string());
+    }
 
-        // check if the order of the vector matters.
-        let pkgs = [&pkg("b", &[dep("a")]), &pkg("a", &[dev_dep("b")])];
+    /// ┌──┐
+    /// │  ▼
+    /// A  B (unversioned dev dependency)
+    /// ▲  │
+    /// └──┘
+    /// Unversioned dev-deps are stripped from the published manifest,
+    /// so they don't create a real cycle.
+    #[test]
+    fn two_packages_unversioned_dev_cycle_is_ok() {
+        let pkgs = [
+            &pkg("a", &[FakeDependency::new("b").unversioned_dev()]),
+            &pkg("b", &[dep("a")]),
+        ];
         assert_eq!(order(&pkgs), ["a", "b"]);
     }
 
@@ -201,9 +211,12 @@ mod tests {
 
     /// ┌──┐
     /// │  ▼
-    /// A  B (dev dependency)
+    /// A  B (versioned dev dependency, also enabled via a feature)
     /// ▲  │
     /// └──┘
+    /// The cycle is detected because `dev_dep` is versioned. The feature map is
+    /// retained as a regression guard: features must not re-introduce the old
+    /// special-casing that excluded feature-enabled dev-deps from the ordering.
     #[test]
     fn two_packages_dev_cycle_with_package_in_features_is_detected() {
         let mut a = pkg("a", &[dev_dep("b")]);
@@ -215,11 +228,13 @@ mod tests {
 
     /// ┌──┐
     /// │  ▼
-    /// A  B (dev dependency)
+    /// A  B (versioned dev dependency, with an unrelated random feature)
     /// ▲  │
     /// └──┘
+    /// Same as above: detection comes from the versioned dev-dep, and the
+    /// feature map guards against features re-introducing special-casing.
     #[test]
-    fn two_packages_dev_cycle_with_random_feature_is_ok() {
+    fn two_packages_dev_cycle_with_random_feature_is_detected() {
         let mut a = pkg("a", &[dev_dep("b")]);
         a.features = [(
             "my_feat".to_string(),
@@ -227,6 +242,29 @@ mod tests {
         )]
         .into();
         let pkgs = [&a, &pkg("b", &[dep("a")])];
+        expect_test::expect!["Circular dependency detected: a -> b"]
+            .assert_eq(&release_order(&pkgs).unwrap_err().to_string());
+    }
+
+    /// A (versioned dev-dep on B) ──► B (no deps)
+    /// `cargo package` validates versioned dev-deps against the registry,
+    /// so B must be published before A.
+    #[test]
+    fn versioned_dev_dep_is_released_before_dependent() {
+        let pkgs = [&pkg("a", &[dev_dep("b")]), &pkg("b", &[])];
+        assert_eq!(order(&pkgs), ["b", "a"]);
+    }
+
+    /// A (unversioned dev-dep on B) ──► B (no deps)
+    /// Unversioned dev-deps are stripped from the published manifest,
+    /// so they don't constrain release order.
+    #[test]
+    fn unversioned_dev_dep_does_not_affect_order() {
+        let pkgs = [
+            &pkg("a", &[FakeDependency::new("b").unversioned_dev()]),
+            &pkg("b", &[]),
+        ];
+        // Order matches input order since there's no dependency edge.
         assert_eq!(order(&pkgs), ["a", "b"]);
     }
 }


### PR DESCRIPTION
## Summary

`cargo publish` (via `cargo package`) validates **all** dependencies against the registry index, including dev-dependencies that have a version requirement. When workspace dev-deps are version-bumped but not yet published, `cargo package` fails:

```
failed to select a version for the requirement `fgumi-sam = "^0.1.1"`
candidate versions found which didn't match: 0.1.0
location searched: crates.io index
required by package `fgumi-metrics v0.1.1`
```

This PR changes `should_dep_be_released_before` to include dev-dependencies that have a version requirement specified, **matching the exact behavior of `cargo publish --workspace`**.

## Matching cargo's behavior

Cargo's [`local_deps()`](https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_package/mod.rs) function:

```rust
// If local dev-dependencies don't have a version specified, they get stripped
// on publish so we should ignore them.
if dep.kind() == DepKind::Development && !dep.specified_req() {
    continue;
};
```

| Dev-dep type | `cargo publish --workspace` | This PR |
|---|---|---|
| With version (e.g., `foo = { path = "..", version = "1.0" }`) | **Included** in ordering | **Included** |
| Without version (e.g., `foo = { path = ".." }`) | **Excluded** (stripped on publish) | **Excluded** |

## Reproduction

- Workspace: [fgumi](https://github.com/fulcrumgenomics/fgumi) — `fgumi-metrics` has a versioned dev-dependency on `fgumi-sam`
- CI failure: https://github.com/fulcrumgenomics/fgumi/actions/runs/22526673914
- Verified locally with `cargo publish --dry-run`: publishing the dependent alone fails; `--workspace` succeeds by ordering the dev-dep first

## What changed

- `should_dep_be_released_before` now returns `true` for `DependencyKind::Development` when the version requirement is specified (`!dep.req.comparators.is_empty()`)
- Added `unversioned_dev()` builder to `FakeDependency` for testing path-only dev-deps
- Updated cycle tests: versioned dev-dep cycles are detected; unversioned dev-dep cycles remain allowed
- Added `dev_dep_is_released_before_dependent` test for the core fix
- `workspace_release_order_is_correct` unchanged (release-plz's own dev-deps are unversioned path deps)

## Prior art

This issue was reported in #1316 and attempted in #1602, #1899, and #2593, all closed. This PR is minimal, matches cargo's exact behavior, and includes a concrete reproduction case.

Fixes #2697