### PR TITLE
feat: add `propagate_major_bump` option for workspace dependencies

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -57,6 +57,7 @@
         "pr_draft": false,
         "pr_labels": [],
         "pr_name": null,
+        "propagate_major_bump": null,
         "publish": null,
         "publish_all_features": null,
         "publish_allow_dirty": null,
@@ -392,6 +393,14 @@
         "name": {
           "type": "string"
         },
+        "propagate_major_bump": {
+          "title": "Propagate Major Bump",
+          "description": "If `true`, when a workspace dependency gets a major version bump,\ndependent crates will also receive a major version bump instead of a patch bump.\nThis is useful for strict semver compliance: if `lib-a` goes from 1.0 to 2.0,\nconsumers of `lib-b` (which depends on `lib-a`) also face a breaking change.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "publish": {
           "title": "Publish",
           "description": "If `false`, don't run `cargo publish`.",
@@ -710,6 +719,14 @@
           "description": "Tera template of the pull request's name created by release-plz.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "propagate_major_bump": {
+          "title": "Propagate Major Bump",
+          "description": "If `true`, when a workspace dependency gets a major version bump,\ndependent crates will also receive a major version bump instead of a patch bump.\nThis is useful for strict semver compliance: if `lib-a` goes from 1.0 to 2.0,\nconsumers of `lib-b` (which depends on `lib-a`) also face a breaking change.",
+          "type": [
+            "boolean",
             "null"
           ]
         },

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -532,9 +532,7 @@ impl PackageConfig {
                 .custom_major_increment_regex
                 .or(default.custom_major_increment_regex),
             git_only: self.git_only.or(default.git_only),
-            propagate_major_bump: self
-                .propagate_major_bump
-                .or(default.propagate_major_bump),
+            propagate_major_bump: self.propagate_major_bump.or(default.propagate_major_bump),
         }
     }
 

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -464,6 +464,12 @@ pub struct PackageConfig {
     /// Custom regex to match commit types that should trigger a major version increment.
     /// Useful when using non-conventional commit prefixes.
     pub custom_major_increment_regex: Option<String>,
+    /// # Propagate Major Bump
+    /// If `true`, when a workspace dependency gets a major version bump,
+    /// dependent crates will also receive a major version bump instead of a patch bump.
+    /// This is useful for strict semver compliance: if `lib-a` goes from 1.0 to 2.0,
+    /// consumers of `lib-b` (which depends on `lib-a`) also face a breaking change.
+    pub propagate_major_bump: Option<bool>,
 }
 
 impl From<PackageConfig> for release_plz_core::UpdateConfig {
@@ -479,6 +485,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             custom_minor_increment_regex: config.custom_minor_increment_regex,
             custom_major_increment_regex: config.custom_major_increment_regex,
             git_only: config.git_only,
+            propagate_major_bump: config.propagate_major_bump == Some(true),
         }
     }
 }
@@ -525,6 +532,9 @@ impl PackageConfig {
                 .custom_major_increment_regex
                 .or(default.custom_major_increment_regex),
             git_only: self.git_only.or(default.git_only),
+            propagate_major_bump: self
+                .propagate_major_bump
+                .or(default.propagate_major_bump),
         }
     }
 

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1655,3 +1655,177 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         )
     );
 }
+
+/// When `propagate_major_bump` is enabled and a dependency gets a major bump,
+/// the dependent crate should also get a major bump instead of a patch bump.
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_propagates_major_bump() {
+    let binary = "binary";
+    let library = "library";
+    // dependency chain: binary -> library
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new(binary)
+            .with_type(PackageType::Bin)
+            .with_path_dependencies(vec![format!("../{library}")]),
+        TestPackage::new(library).with_type(PackageType::Lib),
+    ])
+    .await;
+
+    // Set initial versions: library at 1.0.0 so breaking change = major bump
+    context.set_package_version(library, &Version::new(1, 0, 0));
+    context.set_package_version(binary, &Version::new(1, 0, 0));
+
+    // Enable propagate_major_bump for the workspace
+    context.write_release_plz_toml(
+        r#"
+[workspace]
+propagate_major_bump = true
+"#,
+    );
+
+    context.push_all_changes("set initial versions");
+
+    context.run_release_pr().success();
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    // Introduce a breaking change in the library
+    let lib_file = context.package_path(library).join("src").join("lib.rs");
+    fs_err::write(&lib_file, "pub fn bar() {}").unwrap();
+    context.push_all_changes("breaking change in library");
+
+    context.run_release_pr().success();
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(opened_prs.len(), 1);
+
+    let open_pr = &opened_prs[0];
+
+    // Library should go 1.0.0 -> 2.0.0 (breaking change)
+    // Binary should go 1.0.0 -> 2.0.0 (propagated major bump)
+    let actual_body = open_pr.body.as_ref().unwrap().trim().to_string();
+    assert!(
+        actual_body.contains(&format!("`{library}`: 1.0.0 -> 2.0.0")),
+        "Library should have major bump. PR body:\n{actual_body}"
+    );
+    assert!(
+        actual_body.contains(&format!("`{binary}`: 1.0.0 -> 2.0.0")),
+        "Binary should have propagated major bump. PR body:\n{actual_body}"
+    );
+
+    context.merge_release_pr().await;
+
+    // Verify final Cargo.toml versions
+    let binary_cargo_toml =
+        fs_err::read_to_string(context.package_path(binary).join(CARGO_TOML)).unwrap();
+    expect_test::expect![[r#"
+        [package]
+        name = "binary"
+        version = "2.0.0"
+        edition = "2024"
+        publish = ["test-registry"]
+
+        [dependencies]
+        library = { version = "2.0.0", path = "../library", registry = "test-registry" }
+    "#]]
+    .assert_eq(&binary_cargo_toml);
+}
+
+/// When `propagate_major_bump` is enabled, major bumps should cascade through
+/// the dependency chain: crateA breaks -> crateB major bumps -> crateC major bumps.
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_propagates_major_bump_cascading() {
+    let crate_a = "crate-a";
+    let crate_b = "crate-b";
+    let crate_c = "crate-c";
+    // Dependency chain: crate_c -> crate_b -> crate_a
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new(crate_c)
+            .with_type(PackageType::Bin)
+            .with_path_dependencies(vec![format!("../{crate_b}")]),
+        TestPackage::new(crate_b)
+            .with_type(PackageType::Lib)
+            .with_path_dependencies(vec![format!("../{crate_a}")]),
+        TestPackage::new(crate_a).with_type(PackageType::Lib),
+    ])
+    .await;
+
+    // All crates start at 1.0.0
+    context.set_package_version(crate_a, &Version::new(1, 0, 0));
+    context.set_package_version(crate_b, &Version::new(1, 0, 0));
+    context.set_package_version(crate_c, &Version::new(1, 0, 0));
+
+    // Enable propagate_major_bump for the workspace
+    context.write_release_plz_toml(
+        r#"
+[workspace]
+propagate_major_bump = true
+"#,
+    );
+
+    context.push_all_changes("set initial versions");
+
+    context.run_release_pr().success();
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    // Introduce a breaking change in crate_a
+    let lib_file = context.package_path(crate_a).join("src").join("lib.rs");
+    fs_err::write(&lib_file, "pub fn bar() {}").unwrap();
+    context.push_all_changes("breaking change in crate-a");
+
+    context.run_release_pr().success();
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(opened_prs.len(), 1);
+
+    let open_pr = &opened_prs[0];
+
+    // crate_a: 1.0.0 -> 2.0.0 (breaking change)
+    // crate_b: 1.0.0 -> 2.0.0 (propagated from crate_a)
+    // crate_c: 1.0.0 -> 2.0.0 (propagated from crate_b)
+    let actual_body = open_pr.body.as_ref().unwrap().trim().to_string();
+    assert!(
+        actual_body.contains(&format!("`{crate_a}`: 1.0.0 -> 2.0.0")),
+        "crate-a should have major bump. PR body:\n{actual_body}"
+    );
+    assert!(
+        actual_body.contains(&format!("`{crate_b}`: 1.0.0 -> 2.0.0")),
+        "crate-b should have propagated major bump. PR body:\n{actual_body}"
+    );
+    assert!(
+        actual_body.contains(&format!("`{crate_c}`: 1.0.0 -> 2.0.0")),
+        "crate-c should have cascading propagated major bump. PR body:\n{actual_body}"
+    );
+
+    context.merge_release_pr().await;
+
+    // Verify final Cargo.toml versions
+    let crate_b_cargo_toml =
+        fs_err::read_to_string(context.package_path(crate_b).join(CARGO_TOML)).unwrap();
+    expect_test::expect![[r#"
+        [package]
+        name = "crate-b"
+        version = "2.0.0"
+        edition = "2024"
+        publish = ["test-registry"]
+
+        [dependencies]
+        crate-a = { version = "2.0.0", path = "../crate-a", registry = "test-registry" }
+    "#]]
+    .assert_eq(&crate_b_cargo_toml);
+
+    let crate_c_cargo_toml =
+        fs_err::read_to_string(context.package_path(crate_c).join(CARGO_TOML)).unwrap();
+    expect_test::expect![[r#"
+        [package]
+        name = "crate-c"
+        version = "2.0.0"
+        edition = "2024"
+        publish = ["test-registry"]
+
+        [dependencies]
+        crate-b = { version = "2.0.0", path = "../crate-b", registry = "test-registry" }
+    "#]]
+    .assert_eq(&crate_c_cargo_toml);
+}

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1675,6 +1675,7 @@ async fn release_plz_propagates_major_bump() {
     // Set initial versions: library at 1.0.0 so breaking change = major bump
     context.set_package_version(library, &Version::new(1, 0, 0));
     context.set_package_version(binary, &Version::new(1, 0, 0));
+    context.push_all_changes("set initial versions");
 
     // Enable propagate_major_bump for the workspace
     context.write_release_plz_toml(
@@ -1683,8 +1684,6 @@ async fn release_plz_propagates_major_bump() {
 propagate_major_bump = true
 "#,
     );
-
-    context.push_all_changes("set initial versions");
 
     context.run_release_pr().success();
     context.merge_release_pr().await;
@@ -1755,6 +1754,7 @@ async fn release_plz_propagates_major_bump_cascading() {
     context.set_package_version(crate_a, &Version::new(1, 0, 0));
     context.set_package_version(crate_b, &Version::new(1, 0, 0));
     context.set_package_version(crate_c, &Version::new(1, 0, 0));
+    context.push_all_changes("set initial versions");
 
     // Enable propagate_major_bump for the workspace
     context.write_release_plz_toml(
@@ -1763,8 +1763,6 @@ async fn release_plz_propagates_major_bump_cascading() {
 propagate_major_bump = true
 "#,
     );
-
-    context.push_all_changes("set initial versions");
 
     context.run_release_pr().success();
     context.merge_release_pr().await;

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1827,3 +1827,64 @@ propagate_major_bump = true
     "#]]
     .assert_eq(&crate_c_cargo_toml);
 }
+
+/// When `propagate_major_bump` is enabled and a dependent crate has its own commits,
+/// the major bump propagation should still apply, upgrading it to a breaking bump instead.
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_propagates_major_bump_with_own_commits() {
+    let binary = "binary";
+    let library = "library";
+    // dependency chain: binary -> library
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new(binary)
+            .with_type(PackageType::Bin)
+            .with_path_dependencies(vec![format!("../{library}")]),
+        TestPackage::new(library).with_type(PackageType::Lib),
+    ])
+    .await;
+
+    // Set initial versions: both at 1.0.0
+    context.set_package_version(library, &Version::new(1, 0, 0));
+    context.set_package_version(binary, &Version::new(1, 0, 0));
+    context.push_all_changes("set initial versions");
+
+    // Enable propagate_major_bump for the workspace
+    context.write_release_plz_toml(
+        r#"
+[workspace]
+propagate_major_bump = true
+"#,
+    );
+
+    context.run_release_pr().success();
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    // Introduce a breaking change in the library
+    let lib_file = context.package_path(library).join("src").join("lib.rs");
+    fs_err::write(&lib_file, "pub fn bar() {}").unwrap();
+
+    // Also introduce a change in the binary (its own commit)
+    let bin_file = context.package_path(binary).join("src").join("main.rs");
+    fs_err::write(&bin_file, "fn main() { println!(\"updated\"); }").unwrap();
+    context.push_all_changes("feat: breaking change in library and update in binary");
+
+    context.run_release_pr().success();
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(opened_prs.len(), 1);
+
+    let open_pr = &opened_prs[0];
+
+    // Library should go 1.0.0 -> 2.0.0 (breaking change)
+    // Binary should go 1.0.0 -> 2.0.0 (propagated major bump, even though it has its own commits)
+    let actual_body = open_pr.body.as_ref().unwrap().trim().to_string();
+    assert!(
+        actual_body.contains(&format!("`{library}`: 1.0.0 -> 2.0.0")),
+        "Library should have major bump. PR body:\n{actual_body}"
+    );
+    assert!(
+        actual_body.contains(&format!("`{binary}`: 1.0.0 -> 2.0.0")),
+        "Binary should have propagated major bump even with its own commits. PR body:\n{actual_body}"
+    );
+}

--- a/crates/release_plz_core/src/command/update/update_config.rs
+++ b/crates/release_plz_core/src/command/update/update_config.rs
@@ -30,6 +30,9 @@ pub struct UpdateConfig {
     pub custom_major_increment_regex: Option<String>,
     /// Whether to use git tags instead of registry for determining package versions.
     pub git_only: Option<bool>,
+    /// If `true`, when a workspace dependency gets a major version bump,
+    /// dependent crates will also receive a major version bump instead of a patch bump.
+    pub propagate_major_bump: bool,
 }
 
 /// Package-specific config
@@ -84,6 +87,7 @@ impl Default for UpdateConfig {
             changelog_path: None,
             custom_minor_increment_regex: None,
             custom_major_increment_regex: None,
+            propagate_major_bump: false,
         }
     }
 }

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -365,7 +365,10 @@ impl Updater<'_> {
         // Track which packages had a major version bump (old_major < new_major)
         let mut major_bumped_packages: HashSet<String> = initial_changed_packages
             .iter()
-            .filter(|(pkg, new_version)| new_version.major > pkg.version.major)
+            .filter(|(pkg, new_version)| {
+                new_version.major > pkg.version.major
+                    || (pkg.version.major == 0 && new_version.minor > pkg.version.minor)
+            })
             .map(|(pkg, _)| pkg.name.to_string())
             .collect();
 
@@ -400,7 +403,9 @@ impl Updater<'_> {
                     )?;
 
                     // Track if this package itself got a major bump (for cascading)
-                    if update.1.version.major > p.version.major {
+                    if update.1.version.major > p.version.major
+                        || (p.version.major == 0 && update.1.version.minor > p.version.minor)
+                    {
                         major_bumped_packages.insert(p.name.to_string());
                     }
 

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -147,6 +147,11 @@ impl Updater<'_> {
             }
         }
 
+        // Propagate major bumps to packages that were already updated in the main loop.
+        // If package B has its own commits (e.g. feat → minor bump) but depends on A (major bump),
+        // and propagate_major_bump is enabled for B, upgrade B's version to a breaking bump.
+        self.propagate_major_bump_to_updated_packages(&mut packages_to_update)?;
+
         let changed_packages: Vec<(&Package, Version)> = packages_to_update
             .updates()
             .iter()
@@ -331,6 +336,94 @@ impl Updater<'_> {
         Ok(packages_diffs)
     }
 
+    /// Propagate major bumps to packages that were already updated in the main loop.
+    /// If a package has its own commits (e.g. a `feat` commit → minor bump) but also depends
+    /// on a package that received a major/breaking bump, and `propagate_major_bump` is enabled,
+    /// we upgrade its version to a breaking bump.
+    fn propagate_major_bump_to_updated_packages(
+        &self,
+        packages_to_update: &mut PackagesUpdate,
+    ) -> anyhow::Result<()> {
+        let workspace_manifest = LocalManifest::try_new(self.req.local_manifest())?;
+        let workspace_dependencies = workspace_manifest.get_workspace_dependency_table();
+        let workspace_dir = crate::manifest_dir(self.req.local_manifest())?;
+
+        // Collect packages that had a breaking version bump
+        let major_bumped: HashSet<String> = packages_to_update
+            .updates()
+            .iter()
+            .filter(|(pkg, update)| is_breaking_bump(&pkg.version, &update.version))
+            .map(|(pkg, _)| pkg.name.to_string())
+            .collect();
+
+        if major_bumped.is_empty() {
+            return Ok(());
+        }
+
+        // Build owned (package, new_version) pairs for dependency lookup
+        let changed_packages: Vec<(Package, Version)> = packages_to_update
+            .updates()
+            .iter()
+            .map(|(p, u)| (p.clone(), u.version.clone()))
+            .collect();
+        let changed_packages_refs: Vec<(&Package, Version)> = changed_packages
+            .iter()
+            .map(|(p, v)| (p, v.clone()))
+            .collect();
+
+        // Check each updated package to see if it depends on a major-bumped package
+        for (pkg, update) in packages_to_update.updates_mut() {
+            if !self
+                .req
+                .get_package_config(&pkg.name)
+                .generic
+                .propagate_major_bump
+            {
+                continue;
+            }
+
+            // Already a breaking bump, nothing to do
+            if is_breaking_bump(&pkg.version, &update.version) {
+                continue;
+            }
+
+            // Skip prerelease packages (no clear semver-correct propagation behavior)
+            if pkg.version.is_prerelease() {
+                continue;
+            }
+
+            let deps = pkg.dependencies_to_update(
+                &changed_packages_refs,
+                workspace_dependencies,
+                workspace_dir,
+            )?;
+            let has_major_bump_dep = deps
+                .iter()
+                .any(|dep| major_bumped.contains(dep.name.as_str()));
+
+            if has_major_bump_dep {
+                let propagated_version = breaking_version(&pkg.version);
+                let old_version_str = update.version.to_string();
+                let new_version_str = propagated_version.to_string();
+                info!(
+                    "{}: propagating major bump from dependency. Version upgraded from {old_version_str} to {new_version_str}",
+                    pkg.name
+                );
+                // Update changelog to reflect the new version in headers
+                if let Some(changelog) = &mut update.changelog {
+                    *changelog =
+                        changelog.replace(&old_version_str, &new_version_str);
+                }
+                if let Some(entry) = &mut update.new_changelog_entry {
+                    *entry = entry.replace(&old_version_str, &new_version_str);
+                }
+                update.version = propagated_version;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Return the update to apply to the packages that depend on the `initial_changed_packages`.
     ///
     /// ## Args
@@ -362,13 +455,10 @@ impl Updater<'_> {
         // Keep a copy of all packages that have changed so far
         let mut all_changed_packages: Vec<(&Package, Version)> = initial_changed_packages.to_vec();
 
-        // Track which packages had a major version bump (old_major < new_major)
+        // Track which packages had a breaking version bump
         let mut major_bumped_packages: HashSet<String> = initial_changed_packages
             .iter()
-            .filter(|(pkg, new_version)| {
-                new_version.major > pkg.version.major
-                    || (pkg.version.major == 0 && new_version.minor > pkg.version.minor)
-            })
+            .filter(|(pkg, new_version)| is_breaking_bump(&pkg.version, new_version))
             .map(|(pkg, _)| pkg.name.to_string())
             .collect();
 
@@ -402,10 +492,8 @@ impl Updater<'_> {
                         has_major_bump_dep,
                     )?;
 
-                    // Track if this package itself got a major bump (for cascading)
-                    if update.1.version.major > p.version.major
-                        || (p.version.major == 0 && update.1.version.minor > p.version.minor)
-                    {
+                    // Track if this package itself got a breaking bump (for cascading)
+                    if is_breaking_bump(&p.version, &update.1.version) {
                         major_bumped_packages.insert(p.name.to_string());
                     }
 
@@ -435,29 +523,30 @@ impl Updater<'_> {
         has_major_bump_dep: bool,
     ) -> anyhow::Result<(Package, UpdateResult)> {
         let deps: Vec<&str> = deps.iter().map(|d| d.name.as_str()).collect();
-        let commits = {
-            let change = format!(
-                "chore: updated the following local packages: {}",
-                deps.join(", ")
-            );
-            vec![Commit::new(NO_COMMIT_ID.to_string(), change)]
-        };
         let propagate = has_major_bump_dep
             && self
                 .req
                 .get_package_config(&p.name)
                 .generic
                 .propagate_major_bump;
+        let commits = {
+            let change = if propagate {
+                format!(
+                    "chore!: updated the following local packages: {} (major version bump propagated)",
+                    deps.join(", ")
+                )
+            } else {
+                format!(
+                    "chore: updated the following local packages: {}",
+                    deps.join(", ")
+                )
+            };
+            vec![Commit::new(NO_COMMIT_ID.to_string(), change)]
+        };
         let next_version = if p.version.is_prerelease() {
             p.version.increment_prerelease()
         } else if propagate {
-            if p.version.major == 0 && p.version.minor == 0 {
-                p.version.increment_patch()
-            } else if p.version.major == 0 {
-                p.version.increment_minor()
-            } else {
-                p.version.increment_major()
-            }
+            breaking_version(&p.version)
         } else {
             p.version.increment_patch()
         };
@@ -900,6 +989,26 @@ impl Updater<'_> {
             return Ok(true);
         };
         Ok(!package_files.is_disjoint(&changed_files))
+    }
+}
+
+/// Returns true if the version change represents a breaking/semver-incompatible bump.
+/// For >=1.0: major increases. For 0.x.y (x>0): minor increases. For 0.0.x: patch increases.
+fn is_breaking_bump(old: &Version, new: &Version) -> bool {
+    new.major > old.major
+        || (old.major == 0 && new.minor > old.minor)
+        || (old.major == 0 && old.minor == 0 && new.patch > old.patch)
+}
+
+/// Returns the next breaking version for a package.
+/// For 0.0.x: increment patch. For 0.x.y: increment minor. For >=1.0: increment major.
+fn breaking_version(version: &Version) -> Version {
+    if version.major == 0 && version.minor == 0 {
+        version.increment_patch()
+    } else if version.major == 0 {
+        version.increment_minor()
+    } else {
+        version.increment_major()
     }
 }
 

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -362,6 +362,13 @@ impl Updater<'_> {
         // Keep a copy of all packages that have changed so far
         let mut all_changed_packages: Vec<(&Package, Version)> = initial_changed_packages.to_vec();
 
+        // Track which packages had a major version bump (old_major < new_major)
+        let mut major_bumped_packages: HashSet<String> = initial_changed_packages
+            .iter()
+            .filter(|(pkg, new_version)| new_version.major > pkg.version.major)
+            .map(|(pkg, _)| pkg.name.to_string())
+            .collect();
+
         // Continue updating packages until no more dependencies to update are found
         loop {
             let mut any_package_updated = false;
@@ -379,9 +386,23 @@ impl Updater<'_> {
                     workspace_dir,
                 ) && !deps.is_empty()
                 {
+                    // Check if any dependency had a major bump
+                    let has_major_bump_dep = deps
+                        .iter()
+                        .any(|dep| major_bumped_packages.contains(dep.name.as_str()));
+
                     // This package depends on changed packages, so it needs to be updated
-                    let update =
-                        self.calculate_package_update_result(&deps, p, &mut old_changelogs)?;
+                    let update = self.calculate_package_update_result(
+                        &deps,
+                        p,
+                        &mut old_changelogs,
+                        has_major_bump_dep,
+                    )?;
+
+                    // Track if this package itself got a major bump (for cascading)
+                    if update.1.version.major > p.version.major {
+                        major_bumped_packages.insert(p.name.to_string());
+                    }
 
                     result.push(update.clone());
 
@@ -406,6 +427,7 @@ impl Updater<'_> {
         deps: &[&Package],
         p: &Package,
         old_changelogs: &mut OldChangelogs,
+        has_major_bump_dep: bool,
     ) -> anyhow::Result<(Package, UpdateResult)> {
         let deps: Vec<&str> = deps.iter().map(|d| d.name.as_str()).collect();
         let commits = {
@@ -415,8 +437,22 @@ impl Updater<'_> {
             );
             vec![Commit::new(NO_COMMIT_ID.to_string(), change)]
         };
+        let propagate = has_major_bump_dep
+            && self
+                .req
+                .get_package_config(&p.name)
+                .generic
+                .propagate_major_bump;
         let next_version = if p.version.is_prerelease() {
             p.version.increment_prerelease()
+        } else if propagate {
+            if p.version.major == 0 && p.version.minor == 0 {
+                p.version.increment_patch()
+            } else if p.version.major == 0 {
+                p.version.increment_minor()
+            } else {
+                p.version.increment_major()
+            }
         } else {
             p.version.increment_patch()
         };


### PR DESCRIPTION
This is the only thing that I am missing in release-plz. Great tool, I use it in https://github.com/bluealloy/revm/ for years now!

## Summary

- Adds a new `propagate_major_bump` config option (workspace and per-package level)
- When enabled, if a workspace dependency gets a major version bump, dependent crates also receive a major bump instead of a patch bump
- Cascades through the full dependency chain (A breaks → B major bumps → C major bumps)
- Respects 0.x semver conventions (0.0.x bumps patch, 0.x.y bumps minor)

## Motivation

When `lib-a` goes from 1.0.0 to 2.0.0, crates that depend on it (e.g. `lib-b`) also face a breaking change in their public API surface (re-exported types, trait bounds, etc.). Currently release-plz only gives them a patch bump, which can violate semver for downstream consumers. This option lets maintainers opt into strict semver propagation.

## Changes

- `.schema/latest.json` — added `propagate_major_bump` field to both workspace and package config schemas
- `crates/release_plz/src/config.rs` — config parsing and merge logic for the new option
- `crates/release_plz_core/src/command/update/update_config.rs` — new `propagate_major_bump` field in `UpdateConfig`
- `crates/release_plz_core/src/command/update/updater.rs` — core logic: tracks major-bumped packages and propagates through dependency chain
- `crates/release_plz/tests/all/release_pr.rs` — two integration tests (direct + cascading 3-crate chain)

## Test plan

- [x] Added `release_plz_propagates_major_bump` test (binary depends on library, library breaks → both get major bump)
- [x] Added `release_plz_propagates_major_bump_cascading` test (3-crate chain: A breaks → B major → C major)
- [ ] Both tests require `docker-tests` feature flag to run