### PR TITLE
fix(gitea): use GITHUB_SERVER_URL when origin host is github

### DIFF
--- a/crates/release_plz_core/src/git/gitea_client.rs
+++ b/crates/release_plz_core/src/git/gitea_client.rs
@@ -1,6 +1,7 @@
 use crate::RepoUrl;
 use crate::git::forge::Remote;
 use anyhow::{Context, bail};
+use reqwest::Url;
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
 use secrecy::{ExposeSecret, SecretString};
@@ -19,10 +20,7 @@ impl Gitea {
             ),
         }
 
-        let base_url = url
-            .gitea_api_url()
-            .parse()
-            .context("invalid Gitea API URL")?;
+        let base_url = resolve_base_url(&url)?;
         Ok(Self {
             remote: Remote {
                 base_url,
@@ -41,5 +39,54 @@ impl Gitea {
         auth_header.set_sensitive(true);
         headers.insert(reqwest::header::AUTHORIZATION, auth_header);
         Ok(headers)
+    }
+}
+
+fn resolve_base_url(url: &RepoUrl) -> anyhow::Result<Url> {
+    let mut api_url = url.gitea_api_url();
+
+    // In Gitea/Forgejo actions, checkout can leave an `origin` that still points to github.com
+    // while the actual forge host is exposed via GITHUB_SERVER_URL.
+    if url.host == "github.com"
+        && let Ok(server_url) = std::env::var("GITHUB_SERVER_URL")
+        && let Ok(parsed_server_url) = Url::parse(&server_url)
+        && parsed_server_url.host_str() != Some("github.com")
+    {
+        let mut server = parsed_server_url;
+        server.set_query(None);
+        server.set_fragment(None);
+        server.set_path("/api/v1/");
+        api_url = server.to_string();
+    }
+
+    api_url.parse().context("invalid Gitea API URL")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_base_url;
+    use crate::RepoUrl;
+
+    #[test]
+    fn uses_repo_host_for_gitea_api_by_default() {
+        unsafe {
+            std::env::remove_var("GITHUB_SERVER_URL");
+        }
+        let repo = RepoUrl::new("https://git.cscherr.de/PlexSheep/rough2").unwrap();
+        let api = resolve_base_url(&repo).unwrap();
+        assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
+    }
+
+    #[test]
+    fn uses_github_server_url_when_origin_host_is_github() {
+        unsafe {
+            std::env::set_var("GITHUB_SERVER_URL", "https://git.cscherr.de");
+        }
+        let repo = RepoUrl::new("https://github.com/PlexSheep/rough2").unwrap();
+        let api = resolve_base_url(&repo).unwrap();
+        assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
+        unsafe {
+            std::env::remove_var("GITHUB_SERVER_URL");
+        }
     }
 }

--- a/crates/release_plz_core/src/git/gitea_client.rs
+++ b/crates/release_plz_core/src/git/gitea_client.rs
@@ -64,29 +64,45 @@ fn resolve_base_url(url: &RepoUrl) -> anyhow::Result<Url> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::resolve_base_url;
     use crate::RepoUrl;
 
+    static NO_PARALLEL: Mutex<()> = Mutex::new(());
+
+    fn with_github_server_url(value: Option<&str>, test: impl FnOnce()) {
+        let _guard = NO_PARALLEL.lock().unwrap();
+        let old = std::env::var("GITHUB_SERVER_URL").ok();
+
+        match value {
+            Some(v) => unsafe { std::env::set_var("GITHUB_SERVER_URL", v) },
+            None => unsafe { std::env::remove_var("GITHUB_SERVER_URL") },
+        }
+
+        test();
+
+        match old {
+            Some(v) => unsafe { std::env::set_var("GITHUB_SERVER_URL", v) },
+            None => unsafe { std::env::remove_var("GITHUB_SERVER_URL") },
+        }
+    }
+
     #[test]
     fn uses_repo_host_for_gitea_api_by_default() {
-        unsafe {
-            std::env::remove_var("GITHUB_SERVER_URL");
-        }
-        let repo = RepoUrl::new("https://git.cscherr.de/PlexSheep/rough2").unwrap();
-        let api = resolve_base_url(&repo).unwrap();
-        assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
+        with_github_server_url(None, || {
+            let repo = RepoUrl::new("https://git.cscherr.de/PlexSheep/rough2").unwrap();
+            let api = resolve_base_url(&repo).unwrap();
+            assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
+        });
     }
 
     #[test]
     fn uses_github_server_url_when_origin_host_is_github() {
-        unsafe {
-            std::env::set_var("GITHUB_SERVER_URL", "https://git.cscherr.de");
-        }
-        let repo = RepoUrl::new("https://github.com/PlexSheep/rough2").unwrap();
-        let api = resolve_base_url(&repo).unwrap();
-        assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
-        unsafe {
-            std::env::remove_var("GITHUB_SERVER_URL");
-        }
+        with_github_server_url(Some("https://git.cscherr.de"), || {
+            let repo = RepoUrl::new("https://github.com/PlexSheep/rough2").unwrap();
+            let api = resolve_base_url(&repo).unwrap();
+            assert_eq!(api.as_str(), "https://git.cscherr.de/api/v1/");
+        });
     }
 }


### PR DESCRIPTION
## Summary
- fix Gitea::new to derive API base URL via a small helper so it can detect CI host overrides
- when forge is gitea, origin host is github.com, and GITHUB_SERVER_URL points to a non-GitHub host, use that host for /api/v1/ requests
- add focused unit tests for default behavior and the GITHUB_SERVER_URL override case

## Testing
- Not run locally in this environment: cargo is not installed (cargo: command not found)
- Validation instead: added deterministic unit tests in crates/release_plz_core/src/git/gitea_client.rs that cover both code paths

## Related
Fixes #2707