### PR TITLE
feat: add `semver_check_features` config option

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -67,7 +67,8 @@
         "release_always": null,
         "release_commits": null,
         "repo_url": null,
-        "semver_check": null
+        "semver_check": null,
+        "semver_check_features": null
       }
     }
   },
@@ -451,6 +452,17 @@
             "null"
           ]
         },
+        "semver_check_features": {
+          "title": "Semver Check Features",
+          "description": "If `[\"a\", \"b\", \"c\"]`, add the `--only-explicit-features` and `--features=a,b,c` flags\nto the `cargo-semver-checks` command.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "version_group": {
           "title": "Version group",
           "description": "The name of a group of packages that needs to have the same version.",
@@ -804,6 +816,17 @@
             "boolean",
             "null"
           ]
+        },
+        "semver_check_features": {
+          "title": "Semver Check Features",
+          "description": "If `[\"a\", \"b\", \"c\"]`, add the `--only-explicit-features` and `--features=a,b,c` flags\nto the `cargo-semver-checks` command.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -453,6 +453,10 @@ pub struct PackageConfig {
     /// Controls when to run cargo-semver-checks.
     /// If unspecified, run cargo-semver-checks if the package is a library.
     pub semver_check: Option<bool>,
+    /// # Semver Check Features
+    /// If `["a", "b", "c"]`, add the `--only-explicit-features` and `--features=a,b,c` flags
+    /// to the `cargo-semver-checks` command.
+    pub semver_check_features: Option<Vec<String>>,
     /// # Release
     /// Used to toggle off the update/release process for a workspace or package.
     pub release: Option<bool>,
@@ -479,6 +483,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             custom_minor_increment_regex: config.custom_minor_increment_regex,
             custom_major_increment_regex: config.custom_major_increment_regex,
             git_only: config.git_only,
+            semver_check_features: config.semver_check_features.unwrap_or_default(),
         }
     }
 }
@@ -498,6 +503,9 @@ impl PackageConfig {
     pub fn merge(self, default: Self) -> Self {
         Self {
             semver_check: self.semver_check.or(default.semver_check),
+            semver_check_features: self
+                .semver_check_features
+                .or(default.semver_check_features),
             changelog_path: self.changelog_path.or(default.changelog_path),
             changelog_update: self.changelog_update.or(default.changelog_update),
             features_always_increment_minor: self

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -503,9 +503,7 @@ impl PackageConfig {
     pub fn merge(self, default: Self) -> Self {
         Self {
             semver_check: self.semver_check.or(default.semver_check),
-            semver_check_features: self
-                .semver_check_features
-                .or(default.semver_check_features),
+            semver_check_features: self.semver_check_features.or(default.semver_check_features),
             changelog_path: self.changelog_path.or(default.changelog_path),
             changelog_update: self.changelog_update.or(default.changelog_update),
             features_always_increment_minor: self

--- a/crates/release_plz_core/src/command/update/update_config.rs
+++ b/crates/release_plz_core/src/command/update/update_config.rs
@@ -30,6 +30,9 @@ pub struct UpdateConfig {
     pub custom_major_increment_regex: Option<String>,
     /// Whether to use git tags instead of registry for determining package versions.
     pub git_only: Option<bool>,
+    /// Features to pass to cargo-semver-checks via `--features`.
+    /// When non-empty, `--only-explicit-features` is also passed.
+    pub semver_check_features: Vec<String>,
 }
 
 /// Package-specific config
@@ -69,6 +72,10 @@ impl PackageUpdateConfig {
     pub fn git_only(&self) -> Option<bool> {
         self.generic.git_only
     }
+
+    pub fn semver_check_features(&self) -> &[String] {
+        &self.generic.semver_check_features
+    }
 }
 
 impl Default for UpdateConfig {
@@ -84,6 +91,7 @@ impl Default for UpdateConfig {
             changelog_path: None,
             custom_minor_increment_regex: None,
             custom_major_increment_regex: None,
+            semver_check_features: vec![],
         }
     }
 }

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -267,9 +267,12 @@ impl Updater<'_> {
                                 "Checking API compatibility with cargo-semver-checks..."
                             );
                         });
-                        let semver_check =
-                            semver_check::run_semver_check(&package_path, registry_package_path)
-                                .context("error while running cargo-semver-checks")?;
+                        let semver_check = semver_check::run_semver_check(
+                            &package_path,
+                            registry_package_path,
+                            package_config.semver_check_features(),
+                        )
+                        .context("error while running cargo-semver-checks")?;
                         diff.set_semver_check(semver_check);
                     }
                 }

--- a/crates/release_plz_core/src/semver_check.rs
+++ b/crates/release_plz_core/src/semver_check.rs
@@ -44,6 +44,7 @@ impl SemverCheck {
 pub fn run_semver_check(
     local_package: &Utf8Path,
     registry_package: &Utf8Path,
+    features: &[String],
 ) -> anyhow::Result<SemverCheck> {
     let local_cargo_lock = cargo_lock(local_package);
     let registry_cargo_lock = cargo_lock(registry_package);
@@ -55,12 +56,20 @@ pub fn run_semver_check(
     let local_package_contained_target = local_target_dir.exists();
     let registry_package_contained_target = registry_target_dir.exists();
 
-    let output = Command::new("cargo-semver-checks")
-        .args(["semver-checks", "check-release"])
+    let mut cmd = Command::new("cargo-semver-checks");
+    cmd.args(["semver-checks", "check-release"])
         .arg("--manifest-path")
         .arg(local_package.join(CARGO_TOML))
         .arg("--baseline-root")
-        .arg(registry_package.join(CARGO_TOML))
+        .arg(registry_package.join(CARGO_TOML));
+
+    if !features.is_empty() {
+        cmd.arg("--only-explicit-features");
+        cmd.arg("--features");
+        cmd.arg(features.join(","));
+    }
+
+    let output = cmd
         .output()
         .with_context(|| format!("error while running cargo-semver-checks on {local_package:?}"))?;
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -48,6 +48,7 @@ publish = false # disable `cargo publish` for `package_a`
 [[package]]
 name = "package_b"
 semver_check = true # enable semver_check for `package_b`
+semver_check_features = ["default", "server"] # only check these features for semver
 publish_no_verify = true # add `--no-verify` to `cargo publish` for `package_b`
 publish_features = ["a", "b"] # add `--features=a,b` to `cargo publish` for `package_b`
 publish_all_features = true # add `--all-features` to `cargo publish` for `package_b`
@@ -104,6 +105,7 @@ the following sections:
     packages.
   - [`repo_url`](#the-repo_url-field) — Repository URL.
   - [`semver_check`](#the-semver_check-field) — Run [cargo-semver-checks].
+  - [`semver_check_features`](#the-semver_check_features-field) — List of features to pass to [cargo-semver-checks].
 - [`[[package]]`](#the-package-section) — Package-specific configurations.
   - [`name`](#the-name-field) — Package name. *(Required)*.
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
@@ -133,6 +135,8 @@ the following sections:
     — Pass `--all-features` to `cargo publish`.
   - [`release`](#the-release-field-package-section) - Enable the processing of this package.
   - [`semver_check`](#the-semver_check-field-package-section) — Run [cargo-semver-checks].
+  - [`semver_check_features`](#the-semver_check_features-field-package-section) — List of
+    features to pass to [cargo-semver-checks].
   - [`version_group`](#the-version_group-field) — Group of packages with the same version.
 - [`[changelog]`](#the-changelog-section) — Changelog configuration.
   - [`header`](#the-header-field) — Changelog header.
@@ -740,6 +744,17 @@ API breaking changes of your package:
 
 This field can be overridden in the [`[package]`](#the-package-section) section.
 
+#### The `semver_check_features` field
+
+Pass a list of features to [cargo-semver-checks] when checking for API breaking changes.
+
+- If set to a list of features (e.g. `["default", "server"]`), `release-plz` adds
+  `--only-explicit-features` and `--features=default,server` flags to `cargo-semver-checks`.
+- If not set or if it is empty, `cargo-semver-checks` uses its default heuristic. *(Default)*.
+
+This is useful when non-default features intentionally change the API surface,
+which would otherwise trigger false-positive breaking-change detections.
+
 ### The `[[package]]` section
 
 In this section, you can override some of the `workspace` fields for specific packages.
@@ -884,6 +899,10 @@ Overrides the [`workspace.release`](#the-release-field) field.
 - If `false`, don't.
 
 By default, release-plz runs [cargo-semver-checks] if the package is a library.
+
+#### The `semver_check_features` field (`package` section)
+
+Overrides the [`workspace.semver_check_features`](#the-semver_check_features-field) field.
 
 [cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
 [git-cliff]: https://git-cliff.org


### PR DESCRIPTION
Closes https://github.com/release-plz/release-plz/issues/2291

Currently release-plz invokes `cargo-semver-checks` without any feature flags, so it uses its default heuristic which enables all features except ones prefixed with `_`, `unstable-`, etc. This causes false-positive breaking-change detections for crates whose non-default features intentionally change the API surface.

This adds a `semver_check_features` config field at both workspace and package level. When set, it passes `--only-explicit-features` and `--features <list>` to `cargo-semver-checks`, giving users independent control over which features are checked. The implementation follows the same pattern as `publish_features`. When the field is not set, behavior is unchanged.

Config example:

```toml
[[package]]
name = "my-crate"
semver_check_features = ["default", "server", "client"]
```