### PR TITLE
fix(git_only): fall back to source dir comparison when cargo package fails

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -582,8 +582,20 @@ async fn release_packages(
     repo: &Repo,
     git_client: &GitClient,
 ) -> anyhow::Result<Option<Release>> {
-    // Packages are already ordered by release order.
-    let packages = project.publishable_packages();
+    // Collect releasable packages: publishable ones + git_only packages (which
+    // may have `publish = false` in Cargo.toml but still create git tags/releases).
+    // Without this, monorepos whose ALL crates are `publish = false` get an empty
+    // list and the release command silently does nothing.
+    //
+    // Tracks: <https://github.com/release-plz/release-plz/issues/2595>
+    let git_only_names: Vec<String> = input
+        .metadata
+        .workspace_packages()
+        .iter()
+        .filter(|p| !input.is_publish_enabled(&p.name))
+        .map(|p| p.name.to_string())
+        .collect();
+    let packages = project.releasable_packages(&git_only_names);
     if packages.is_empty() {
         info!("nothing to release");
     }

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -148,16 +148,47 @@ fn process_git_only_package(
     // Run cargo package so we have our finalized package.
     // In git_only mode we always package the whole workspace to make sure
     // local path dependencies are materialized as local tarballs.
-    run_cargo_package(&worktree).context("run cargo package")?;
+    //
+    // This can fail for workspaces whose internal path dependencies are not
+    // published to crates.io and whose `[workspace.dependencies]` path entries
+    // lack a `version` field (either entirely or at the baseline commit).
+    // In that case, we fall back to reading package metadata directly from the
+    // worktree source instead of the packaged tarball — `package_compare` then
+    // hashes source files directly (see `get_cargo_package_files`).
+    //
+    // Tracks: <https://github.com/release-plz/release-plz/issues/2595>
+    let cargo_package_ok = match run_cargo_package(&worktree) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                "cargo package failed in git_only mode for package {}, \
+                 falling back to source directory comparison: {e:#}",
+                package.name
+            );
+            false
+        }
+    };
 
-    // Get the package metadata
-    let single_package = get_cargo_package(&worktree, &package.name).with_context(|| {
-        format!(
-            "get cargo package {} from worktree at {:?}",
-            package.name,
-            worktree.path()
-        )
-    })?;
+    // Get the package metadata. When cargo package succeeded we read the
+    // tarball metadata (canonical path); otherwise we read it from the
+    // worktree source directly.
+    let single_package = if cargo_package_ok {
+        get_cargo_package(&worktree, &package.name).with_context(|| {
+            format!(
+                "get cargo package {} from worktree at {:?}",
+                package.name,
+                worktree.path()
+            )
+        })?
+    } else {
+        get_cargo_package_from_source(&worktree, &package.name).with_context(|| {
+            format!(
+                "get cargo package {} from source at {:?}",
+                package.name,
+                worktree.path()
+            )
+        })?
+    };
 
     let registry_package = RegistryPackage::new(single_package, Some(release_commit));
     Ok(Some((registry_package, worktree)))
@@ -212,6 +243,39 @@ fn get_cargo_package(worktree: &GitWorkTree, package_name: &str) -> anyhow::Resu
         .clone();
 
     Ok(single_package)
+}
+
+/// Fallback: read package metadata directly from the worktree source (no `cargo package`).
+///
+/// Used when `run_cargo_package` fails (e.g. for monorepos with path dependencies
+/// whose versions cannot be resolved through the registry). The returned `Package`
+/// points to the source directory rather than a `target/package/<name>-<version>/`
+/// tarball — `package_compare::are_packages_equal` handles this via the source-
+/// directory fallback in `get_cargo_package_files`.
+fn get_cargo_package_from_source(
+    worktree: &GitWorkTree,
+    package_name: &str,
+) -> anyhow::Result<Package> {
+    let worktree_path = to_utf8_path(worktree.path())?;
+    let manifest_path = worktree_path.join("Cargo.toml");
+
+    let metadata = MetadataCommand::new()
+        .current_dir(worktree_path.as_std_path())
+        .no_deps()
+        .manifest_path(&manifest_path)
+        .exec()
+        .context("get cargo metadata for worktree")?;
+
+    let package = metadata
+        .workspace_packages()
+        .into_iter()
+        .find(|p| p.name == package_name)
+        .with_context(|| {
+            format!("package {package_name:?} not found in workspace at {worktree_path:?}")
+        })?
+        .clone();
+
+    Ok(package)
 }
 
 /// Determine next version of packages.

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -26,6 +26,20 @@ pub fn are_packages_equal(
         "compare local package {:?} with registry package {:?}",
         local_package, registry_package
     );
+
+    // Source-vs-source fallback: when cargo package failed in the git_only flow
+    // (see `next_ver::get_cargo_package_from_source`), `registry_package` points
+    // to a worktree source directory rather than a `target/package/<name>-<v>`
+    // tarball. In that case there's no `Cargo.toml.orig` and we cannot use the
+    // cargo-package-list path; compare directly from source using a filesystem
+    // walk that respects git-tracked files.
+    //
+    // Tracks: <https://github.com/release-plz/release-plz/issues/2595>
+    let registry_is_source_dir = !registry_package.join("Cargo.toml.orig").exists();
+    if registry_is_source_dir {
+        return are_source_dirs_equal(local_package, registry_package);
+    }
+
     if !are_cargo_toml_equal(local_package, registry_package) {
         debug!("Cargo.toml is different");
         return Ok(false);
@@ -100,6 +114,124 @@ fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> anyhow::Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
     fs_err::rename(from, to).with_context(|| format!("cannot rename {from:?} to {to:?}"))
+}
+
+/// Compare two worktree source directories file-by-file.
+///
+/// Used as a fallback when `cargo package` fails for the baseline commit in
+/// `git_only` mode (see `next_ver::process_git_only_package`). Because the
+/// baseline has no packaged tarball we cannot rely on the `cargo package --list`
+/// path; instead we list files via `git ls-files` in each source directory and
+/// hash them, skipping any file not tracked by git.
+///
+/// This is a more conservative comparison than the packaged-tarball one:
+/// - Source files that would have been excluded by `Cargo.toml` `exclude` / `include`
+///   rules (e.g. `target/`, hidden dev helpers) are skipped because they are
+///   normally not tracked by git anyway.
+/// - Files listed by `.gitignore` are excluded.
+/// - Generated files (`Cargo.lock`, `Cargo.toml.orig`) are ignored.
+///
+/// Tracks: <https://github.com/release-plz/release-plz/issues/2595>
+fn are_source_dirs_equal(
+    local_package: &Utf8Path,
+    registry_package: &Utf8Path,
+) -> anyhow::Result<bool> {
+    // Compare `Cargo.toml` verbatim — this is the source manifest on both sides
+    // (not a `Cargo.toml.orig` tarball artifact).
+    if !are_files_equal(
+        &local_package.join(CARGO_TOML),
+        &registry_package.join(CARGO_TOML),
+    )
+    .unwrap_or(false)
+    {
+        debug!("source Cargo.toml is different");
+        return Ok(false);
+    }
+
+    let local_files = list_git_tracked_files(local_package).with_context(|| {
+        format!("cannot list git-tracked files in local source at {local_package:?}")
+    })?;
+    let registry_files = list_git_tracked_files(registry_package).with_context(|| {
+        format!("cannot list git-tracked files in registry source at {registry_package:?}")
+    })?;
+
+    let local_set: std::collections::BTreeSet<&Utf8PathBuf> = local_files
+        .iter()
+        .filter(|f| is_comparable_source_file(f))
+        .collect();
+    let registry_set: std::collections::BTreeSet<&Utf8PathBuf> = registry_files
+        .iter()
+        .filter(|f| is_comparable_source_file(f))
+        .collect();
+
+    if local_set != registry_set {
+        debug!(
+            "source file lists differ: local has {} files, registry has {}",
+            local_set.len(),
+            registry_set.len()
+        );
+        return Ok(false);
+    }
+
+    for rel_path in local_set {
+        let local_path = local_package.join(rel_path);
+        let registry_path = registry_package.join(rel_path);
+        if !local_path.exists() || !registry_path.exists() {
+            continue;
+        }
+        if local_path.is_symlink() || registry_path.is_symlink() {
+            continue;
+        }
+        if !are_files_equal(&local_path, &registry_path)
+            .with_context(|| format!("cannot compare {local_path:?} vs {registry_path:?}"))?
+        {
+            debug!("source file {rel_path} differs");
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Run `git ls-files` in `package` and return the tracked file paths relative
+/// to that directory. Paths are sorted for deterministic comparison.
+fn list_git_tracked_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {
+    let output = std::process::Command::new("git")
+        .current_dir(package.as_std_path())
+        .args(["ls-files", "-z"])
+        .output()
+        .with_context(|| format!("cannot run git ls-files in {package:?}"))?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "git ls-files failed in {:?}: {}",
+        package,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut files: Vec<Utf8PathBuf> = output
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .filter_map(|bytes| std::str::from_utf8(bytes).ok())
+        .map(Utf8PathBuf::from)
+        .collect();
+    files.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    Ok(files)
+}
+
+/// Files that should be skipped when comparing source directories.
+///
+/// We filter out build artifacts and auto-generated files that would otherwise
+/// cause spurious differences between two source trees.
+fn is_comparable_source_file(path: &Utf8Path) -> bool {
+    !matches!(
+        path.file_name(),
+        Some("Cargo.lock")
+            | Some("Cargo.toml.orig")
+            | Some("Cargo.toml.orig.orig")
+            | Some(".cargo_vcs_info.json")
+    )
 }
 
 pub fn get_cargo_package_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {
@@ -277,4 +409,152 @@ fn read_package_metadata(
         .cloned()
         .context("cannot find package in Cargo.toml")?;
     Ok(package)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Create a throwaway git repo under `root` containing two identical source
+    /// package directories `a/` and `b/`. Both have a minimal `Cargo.toml` plus
+    /// an optional additional file, mimicking worktree source trees that might
+    /// be compared when `cargo package` failed in `git_only` mode.
+    fn init_repo_with_two_source_packages(
+        root: &Utf8Path,
+        extra_file: Option<(&str, &str)>,
+    ) -> anyhow::Result<()> {
+        Command::new("git")
+            .current_dir(root)
+            .args(["init", "-q"])
+            .status()?;
+        Command::new("git")
+            .current_dir(root)
+            .args(["config", "user.email", "test@example.com"])
+            .status()?;
+        Command::new("git")
+            .current_dir(root)
+            .args(["config", "user.name", "test"])
+            .status()?;
+
+        let cargo_toml = r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2021"
+"#;
+        for dir in ["a", "b"] {
+            let pkg = root.join(dir);
+            fs_err::create_dir_all(&pkg)?;
+            fs_err::write(pkg.join("Cargo.toml"), cargo_toml)?;
+            if let Some((name, contents)) = extra_file {
+                fs_err::write(pkg.join(name), contents)?;
+            }
+        }
+        Command::new("git")
+            .current_dir(root)
+            .args(["add", "-A"])
+            .status()?;
+        Command::new("git")
+            .current_dir(root)
+            .args(["commit", "-qm", "init"])
+            .status()?;
+        Ok(())
+    }
+
+    #[test]
+    fn source_dir_comparison_identical_sources_are_equal() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        init_repo_with_two_source_packages(&root, Some(("lib.rs", "fn a() {}\n")))
+            .expect("init repo");
+
+        let result =
+            are_packages_equal(&root.join("a"), &root.join("b")).expect("are_packages_equal");
+        assert!(
+            result,
+            "two source directories with identical content must compare equal"
+        );
+    }
+
+    #[test]
+    fn source_dir_comparison_different_content_is_not_equal() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        init_repo_with_two_source_packages(&root, Some(("lib.rs", "fn a() {}\n")))
+            .expect("init repo");
+
+        // Make `a/lib.rs` differ AFTER initial commit; git ls-files still reports
+        // the tracked file, but content hash will differ.
+        fs_err::write(root.join("a").join("lib.rs"), "fn different() {}\n").unwrap();
+
+        let result =
+            are_packages_equal(&root.join("a"), &root.join("b")).expect("are_packages_equal");
+        assert!(
+            !result,
+            "source directories with differing file content must compare NOT equal"
+        );
+    }
+
+    #[test]
+    fn source_dir_comparison_different_cargo_toml_is_not_equal() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        init_repo_with_two_source_packages(&root, None).expect("init repo");
+
+        // Change `a/Cargo.toml`.
+        fs_err::write(
+            root.join("a").join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.2.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let result =
+            are_packages_equal(&root.join("a"), &root.join("b")).expect("are_packages_equal");
+        assert!(
+            !result,
+            "source directories with differing Cargo.toml must compare NOT equal"
+        );
+    }
+
+    #[test]
+    fn source_dir_comparison_ignores_cargo_lock_and_vcs_info() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        init_repo_with_two_source_packages(&root, Some(("lib.rs", "fn a() {}\n")))
+            .expect("init repo");
+
+        // Create untracked Cargo.lock and .cargo_vcs_info.json in `a`.
+        // These files are filtered by `is_comparable_source_file` and must not
+        // affect the comparison. `git ls-files` also won't return them since
+        // they're untracked.
+        fs_err::write(root.join("a").join("Cargo.lock"), "# lock\n").unwrap();
+        fs_err::write(
+            root.join("a").join(".cargo_vcs_info.json"),
+            "{\"git\": {\"sha1\": \"deadbeef\"}}",
+        )
+        .unwrap();
+
+        let result =
+            are_packages_equal(&root.join("a"), &root.join("b")).expect("are_packages_equal");
+        assert!(
+            result,
+            "Cargo.lock and .cargo_vcs_info.json must be ignored in source comparison"
+        );
+    }
+
+    #[test]
+    fn is_comparable_source_file_filters_known_artifacts() {
+        assert!(!is_comparable_source_file(Utf8Path::new("Cargo.lock")));
+        assert!(!is_comparable_source_file(Utf8Path::new("Cargo.toml.orig")));
+        assert!(!is_comparable_source_file(Utf8Path::new(
+            "Cargo.toml.orig.orig"
+        )));
+        assert!(!is_comparable_source_file(Utf8Path::new(
+            ".cargo_vcs_info.json"
+        )));
+        assert!(is_comparable_source_file(Utf8Path::new("src/lib.rs")));
+        assert!(is_comparable_source_file(Utf8Path::new("Cargo.toml")));
+        assert!(is_comparable_source_file(Utf8Path::new("README.md")));
+    }
 }

--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -114,6 +114,28 @@ impl Project {
             .collect()
     }
 
+    /// Packages that should be processed by the `release` command.
+    ///
+    /// In `git_only` mode, packages with `publish = false` in their Cargo.toml
+    /// are still eligible for release (git tag + GitHub release) even though
+    /// they won't be published to a cargo registry. Without this, the entire
+    /// release pipeline silently does nothing for unpublished monorepos.
+    ///
+    /// Tracks: <https://github.com/release-plz/release-plz/issues/2595>
+    pub fn releasable_packages(&self, git_only_names: &[String]) -> Vec<&Package> {
+        if git_only_names.is_empty() {
+            return self.publishable_packages();
+        }
+        let mut names = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for p in &self.packages {
+            if (p.is_publishable() || git_only_names.contains(&p.name)) && names.insert(&p.name) {
+                result.push(p);
+            }
+        }
+        result
+    }
+
     /// Get all packages, including non-publishable.
     pub fn workspace_packages(&self) -> Vec<&Package> {
         self.packages.iter().collect()


### PR DESCRIPTION
Fixes #2595 (Case 2/B: path deps without version specifiers in git_only mode).

## Problem

`release-plz release-pr` runs `cargo package --allow-dirty --workspace` against the baseline tag checkout in git_only mode. For monorepos whose `[workspace.dependencies]` path entries lack a `version` field at the baseline commit, this fails with:

```
dependency `coordinode-core` does not specify a version
```

Adding version specifiers on HEAD doesn't help — the baseline commit (release tag) still has the old Cargo.toml.

Separately, `release-plz release` uses `publishable_packages()` which filters out all crates with `publish = false`, so monorepos distributing via git only get "nothing to release" after merging a release PR.

## Changes

**`next_ver.rs`**: `process_git_only_package` no longer bails when `run_cargo_package` fails. It logs a warning and reads package metadata directly from the worktree source via `MetadataCommand` (`get_cargo_package_from_source`).

**`package_compare.rs`**: `are_packages_equal` detects source-directory baselines (no `Cargo.toml.orig` sidecar) and switches to `are_source_dirs_equal` — compares `Cargo.toml` verbatim, lists tracked files via `git ls-files -z`, filters build artifacts, hashes pairwise.

**`project.rs`**: new `releasable_packages(git_only_names)` includes git_only packages alongside publishable ones.

**`release.rs`**: `release_packages` uses `releasable_packages` instead of `publishable_packages` so git tag + GitHub release creation works for unpublished monorepos.

## Tests

5 unit tests in `package_compare.rs`: identical sources, differing content, differing Cargo.toml, ignored artifacts, filter function. All 76 existing unit tests pass.

Verified end-to-end on a 10-crate workspace that hits both failure modes in v0.3.157.

## Not covered

Case 3 from #2595 (@chaz-polymarket — per-package `git_tag_name` overrides causing manifest warnings) is a separate root cause. Split to #2790.