### PR TITLE
Add post_update_commands config option for release-pr

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -52,6 +52,7 @@
         "git_tag_enable": null,
         "git_tag_name": null,
         "max_analyze_commits": 1000,
+        "post_update_commands": [],
         "pr_body": null,
         "pr_branch_prefix": null,
         "pr_draft": false,
@@ -673,6 +674,15 @@
           "format": "uint32",
           "default": 1000,
           "minimum": 0
+        },
+        "post_update_commands": {
+          "title": "Post Update Commands",
+          "description": "Shell commands to run after version bumps and changelog updates,\nbut before the release PR is created/updated.\nUseful for updating secondary lockfiles or running code generation\nthat depends on the new version.\nEach command is executed in the project root directory.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         },
         "pr_body": {
           "title": "PR Body",

--- a/crates/release_plz/src/args/release_pr.rs
+++ b/crates/release_plz/src/args/release_pr.rs
@@ -26,12 +26,14 @@ impl ReleasePr {
         let pr_labels = config.workspace.pr_labels.clone();
         let pr_draft = config.workspace.pr_draft;
         let update_request = self.update.update_request(config, cargo_metadata)?;
+        let post_update_commands = config.workspace.post_update_commands.clone();
         let request = ReleasePrRequest::new(update_request)
             .mark_as_draft(pr_draft)
             .with_labels(pr_labels)
             .with_branch_prefix(pr_branch_prefix)
             .with_pr_name_template(pr_name)
-            .with_pr_body_template(pr_body);
+            .with_pr_body_template(pr_body)
+            .with_post_update_commands(post_update_commands);
         Ok(request)
     }
 }

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -189,6 +189,14 @@ pub struct Workspace {
     /// # PR Branch Prefix
     /// Prefix for the PR Branch
     pub pr_branch_prefix: Option<String>,
+    /// # Post Update Commands
+    /// Shell commands to run after version bumps and changelog updates,
+    /// but before the release PR is created/updated.
+    /// Useful for updating secondary lockfiles or running code generation
+    /// that depends on the new version.
+    /// Each command is executed in the project root directory.
+    #[serde(default)]
+    pub post_update_commands: Vec<String>,
     /// # Publish Timeout
     /// Timeout for the publishing process
     pub publish_timeout: Option<String>,
@@ -230,6 +238,7 @@ impl Default for Workspace {
             pr_draft: false,
             pr_labels: Vec::new(),
             pr_branch_prefix: None,
+            post_update_commands: Vec::new(),
             publish_timeout: None,
             release_commits: None,
             release_always: None,
@@ -611,6 +620,7 @@ mod tests {
                 pr_draft: false,
                 pr_labels: vec![],
                 pr_branch_prefix: Some("f-".to_string()),
+                post_update_commands: Vec::new(),
                 publish_timeout: Some("10m".to_string()),
                 release_commits: Some("^feat:".to_string()),
                 release_always: None,
@@ -726,6 +736,7 @@ mod tests {
                 pr_draft: false,
                 pr_labels: vec!["label1".to_string()],
                 pr_branch_prefix: Some("f-".to_string()),
+                post_update_commands: Vec::new(),
                 packages_defaults: PackageConfig {
                     semver_check: None,
                     changelog_update: true.into(),
@@ -772,6 +783,7 @@ mod tests {
             pr_draft = false
             pr_labels = ["label1"]
             pr_branch_prefix = "f-"
+            post_update_commands = []
             publish_timeout = "10m"
             repo_url = "https://github.com/release-plz/release-plz"
             release_commits = "^feat:"
@@ -908,5 +920,28 @@ unknown = false"#;
 
         let serialized = toml::to_string(&config).unwrap();
         assert!(serialized.contains(r#"custom_minor_increment_regex = "minor|enhancement""#));
+    }
+
+    #[test]
+    fn post_update_commands_is_deserialized() {
+        let config = &format!(
+            "{BASE_WORKSPACE_CONFIG}\n\
+            post_update_commands = [\"cargo fetch --manifest-path=tests/Cargo.toml\", \"echo done\"]"
+        );
+
+        let mut expected_config = create_base_workspace_config();
+        expected_config.workspace.post_update_commands = vec![
+            "cargo fetch --manifest-path=tests/Cargo.toml".to_string(),
+            "echo done".to_string(),
+        ];
+
+        let config: Config = toml::from_str(config).unwrap();
+        assert_eq!(config, expected_config);
+    }
+
+    #[test]
+    fn post_update_commands_defaults_to_empty() {
+        let config: Config = toml::from_str(BASE_WORKSPACE_CONFIG).unwrap();
+        assert!(config.workspace.post_update_commands.is_empty());
     }
 }

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -33,6 +33,8 @@ pub struct ReleasePrRequest {
     labels: Vec<String>,
     /// PR Branch Prefix
     branch_prefix: String,
+    /// Shell commands to run after version bumps but before PR creation.
+    post_update_commands: Vec<String>,
     pub update_request: UpdateRequest,
 }
 
@@ -44,6 +46,7 @@ impl ReleasePrRequest {
             draft: false,
             labels: vec![],
             branch_prefix: DEFAULT_BRANCH_PREFIX.to_string(),
+            post_update_commands: vec![],
             update_request,
         }
     }
@@ -72,6 +75,11 @@ impl ReleasePrRequest {
         if let Some(branch_prefix) = pr_branch_prefix {
             self.branch_prefix = branch_prefix;
         }
+        self
+    }
+
+    pub fn with_post_update_commands(mut self, commands: Vec<String>) -> Self {
+        self.post_update_commands = commands;
         self
     }
 }
@@ -144,6 +152,11 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
     let (packages_to_update, _temp_repository) = update(&new_update_request)
         .await
         .context("failed to update packages")?;
+
+    if !input.post_update_commands.is_empty() && !packages_to_update.updates().is_empty() {
+        run_post_update_commands(&input.post_update_commands, &tmp_project_root)?;
+    }
+
     let git_client = input
         .update_request
         .git_client()?
@@ -502,4 +515,101 @@ fn add_changes_and_commit(repository: &Repo, commit_message: &str) -> anyhow::Re
     repository.add(&changes_expect_typechanges)?;
     repository.commit_signed(commit_message)?;
     Ok(())
+}
+
+fn run_post_update_commands(commands: &[String], project_root: &Utf8Path) -> anyhow::Result<()> {
+    for command in commands {
+        info!("running post-update command: {command}");
+        let (shell, flag) = if cfg!(windows) {
+            ("cmd", "/C")
+        } else {
+            ("sh", "-c")
+        };
+        let output = std::process::Command::new(shell)
+            .arg(flag)
+            .arg(command)
+            .current_dir(project_root)
+            .output()
+            .with_context(|| format!("failed to execute post-update command: {command}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "post-update command failed (exit {}): {command}\n{stderr}",
+                output.status.code().unwrap_or(-1)
+            );
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.is_empty() {
+            debug!("post-update command output: {stdout}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn post_update_command_succeeds() {
+        let dir = tempdir().unwrap();
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        let commands = vec!["echo hello".to_string()];
+        run_post_update_commands(&commands, path).unwrap();
+    }
+
+    #[test]
+    fn post_update_command_fails_on_bad_exit() {
+        let dir = tempdir().unwrap();
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        let commands = vec!["exit 1".to_string()];
+        let err = run_post_update_commands(&commands, path).unwrap_err();
+        assert!(err.to_string().contains("post-update command failed"));
+    }
+
+    #[test]
+    fn post_update_command_runs_in_project_root() {
+        let dir = tempdir().unwrap();
+        let marker = dir.path().join("marker.txt");
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        let commands = vec!["touch marker.txt".to_string()];
+        run_post_update_commands(&commands, path).unwrap();
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn post_update_commands_run_in_order() {
+        let dir = tempdir().unwrap();
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        let commands = vec![
+            "echo first > order.txt".to_string(),
+            "echo second >> order.txt".to_string(),
+        ];
+        run_post_update_commands(&commands, path).unwrap();
+        let content = std::fs::read_to_string(dir.path().join("order.txt")).unwrap();
+        #[cfg(not(windows))]
+        assert_eq!(content.trim(), "first\nsecond");
+        #[cfg(windows)]
+        assert_eq!(content.trim(), "first \r\nsecond");
+    }
+
+    #[test]
+    fn post_update_commands_stop_on_first_failure() {
+        let dir = tempdir().unwrap();
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        let commands = vec![
+            "exit 1".to_string(),
+            "touch should_not_exist.txt".to_string(),
+        ];
+        let _err = run_post_update_commands(&commands, path);
+        assert!(!dir.path().join("should_not_exist.txt").exists());
+    }
+
+    #[test]
+    fn empty_commands_is_noop() {
+        let dir = tempdir().unwrap();
+        let path = Utf8Path::from_path(dir.path()).unwrap();
+        run_post_update_commands(&[], path).unwrap();
+    }
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -85,6 +85,7 @@ the following sections:
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`git_tag_name`](#the-git_tag_name-field) — Customize git tag pattern.
   - [`git_only`](#the-git_only-field) — Use git tags instead of cargo registry.
+  - [`post_update_commands`](#the-post_update_commands-field) — Run commands after version bumps.
   - [`pr_branch_prefix`](#the-pr_branch_prefix-field) — Release PR branch prefix.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
   - [`pr_name`](#the-pr_name-field) — Customize the name of the release Pull Request.
@@ -524,6 +525,16 @@ pr_body = """
 This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
 """
 ````
+
+#### The `post_update_commands` field
+
+Shell commands to run after version bumps and changelog updates,
+but before the release PR is created or updated.
+Each command is executed in the project root directory via `sh -c` on Unix
+and `cmd /C` on Windows.
+If any command fails, the release PR is not created.
+
+By default, it is empty and no commands are run.
 
 #### The `pr_branch_prefix` field
 


### PR DESCRIPTION
Add a workspace-level `post_update_commands` configuration option that runs shell commands after version bumps and changelog updates but before the release PR is created.

This enables workflows like updating secondary lockfiles that depend on bumped versions, which otherwise cause CI failures on the release PR.

Closes #2805