### PR TITLE
feat: add `branch` variable to pr title

### DIFF
--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -490,7 +490,7 @@ async fn release_plz_should_set_custom_pr_details() {
 
     let config = r#"
 [workspace]
-pr_name = "release:{% if package and version %} {{ package }} {{ version }}{% endif %}"
+pr_name = "release:{% if package and version and branch %} {{ package }} {{ version }} {{ branch }}{% endif %}"
 pr_body = """
 {% for release in releases %}
 {% if release.title %}
@@ -509,7 +509,7 @@ Changes:
     context.run_release_pr().success();
     let today = today();
 
-    let expected_title = format!("release: {} 0.1.0", context.gitea.repo);
+    let expected_title = format!("release: {} 0.1.0 main", context.gitea.repo);
     let opened_prs = context.opened_release_prs().await;
     assert_eq!(opened_prs.len(), 1);
     assert_eq!(opened_prs[0].title, expected_title);

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -1,6 +1,6 @@
 use crate::{
     PackagesUpdate, ReleaseInfo,
-    tera::{PACKAGE_VAR, RELEASES_VAR, VERSION_VAR, render_template},
+    tera::{BRANCH_VAR, PACKAGE_VAR, RELEASES_VAR, VERSION_VAR, render_template},
 };
 use chrono::SecondsFormat;
 
@@ -67,6 +67,7 @@ impl Pr {
             title: pr_title(
                 packages_to_update,
                 project_contains_multiple_pub_packages,
+                default_branch,
                 title_template,
             )?,
             body: pr_body(packages_to_update, body_template)?,
@@ -99,6 +100,7 @@ fn release_branch(prefix: &str) -> String {
 fn pr_title(
     packages_to_update: &PackagesUpdate,
     project_contains_multiple_pub_packages: bool,
+    default_branch: &str,
     title_template: Option<String>,
 ) -> anyhow::Result<String> {
     let updates = packages_to_update.updates();
@@ -121,6 +123,8 @@ fn pr_title(
         if are_all_versions_equal() {
             context.insert(VERSION_VAR, first_version.to_string().as_str());
         }
+
+        context.insert(BRANCH_VAR, default_branch);
 
         render_template(&title_template, &context, "pr_name")?
     } else if updates.len() == 1 && project_contains_multiple_pub_packages {

--- a/crates/release_plz_core/src/tera.rs
+++ b/crates/release_plz_core/src/tera.rs
@@ -2,6 +2,7 @@ use anyhow::Context as _;
 
 use crate::Remote;
 
+pub const BRANCH_VAR: &str = "branch";
 pub const PACKAGE_VAR: &str = "package";
 pub const VERSION_VAR: &str = "version";
 pub const CHANGELOG_VAR: &str = "changelog";


### PR DESCRIPTION
This allows the use of `branch` inside the PR title.

We're trying out `release-plz` in `axum` and we wanted to try it out with releases from multiple branches (`main` for new breaking release, `0.8.x` for backports to  older version etc.)

Currently, all PRs are named `chore: release` because we have multiple packages with different versions. We would like the names to be different for each branch.

This PR adds `branch` just into `pr_title` but I assume it should also be added at least into `pr_body` and maybe other places?

 I've added the variable into one test. Docs also need updates, but I wanted to check that a change in this direction is ok.