### PR TITLE
docs: show popular release-plz users

### DIFF
--- a/website/docs/release-plz-in-the-wild.md
+++ b/website/docs/release-plz-in-the-wild.md
@@ -4,20 +4,20 @@ This page shows what projects use release-plz.
 
 ## Popular projects
 
-Here are some popular projects using release-plz:
+Here are some popular projects using release-plz, sorted by approximate GitHub stars:
 
-- [aws-lambda-rust-runtime](https://github.com/aws/aws-lambda-rust-runtime/blob/6b9ff4e7392b025c986510d86de9b3afe68701bb/.github/workflows/release-plz.yml#L28)
-- [SurrealDB](https://github.com/surrealdb/surrealdb/blob/567832825a9ad660b002d96030c711a5f3d6c1e7/.github/workflows/reusable_publish_version.yml#L559)
-- [windows-drivers-rs](https://github.com/microsoft/windows-drivers-rs/blob/45811e309771f95d860c05a281efd42840a866cc/release-plz.toml)
-- [tokei](https://github.com/XAMPPRocky/tokei/blob/476bf2a70709e9a03de2d6c0875870ca09c251d2/.github/workflows/release-plz.yaml)
-- [farm](https://github.com/farm-fe/farm/blob/b4e02d43df294188749abafbe2f0da7692fffa4d/.github/workflows/release-plz.yaml)
-- [cargo-generate](https://github.com/cargo-generate/cargo-generate/blob/859ecce6e1d49d9c84a9d7cc14eab130aba67a5a/.github/workflows/release-pr.yml)
-- [pavex](https://github.com/LukeMathWalker/pavex/blob/0e67806d7dcd990824161fcf5ddadca925c4a87c/.github/workflows/publish.yml)
-- [octocrab](https://github.com/XAMPPRocky/octocrab/blob/6004d5059bf4dffa211780fd7db9710b744a03ab/.github/workflows/release-plz.yml)
-- [crux](https://github.com/redbadger/crux/blob/72ae93a4fe15011df93a251707af439771b3be12/scripts/release-pr.sh)
-- [daktilo](https://github.com/orhun/daktilo/blob/9e2bb1a955d5f1e51f4b77ecef4f518ba66e06d5/.github/workflows/cd.yml#L13)
-- [trillium](https://github.com/trillium-rs/trillium/blob/5d7d0ddde14006193a346c7ef7c559f09f965eaf/.github/workflows/release.yml)
-- [rabbitmq-stream-rust-client](https://github.com/rabbitmq/rabbitmq-stream-rust-client/blob/551d00e2de7917917fd2db1920270fe8896cdeb6/.github/workflows/release-plz.yml)
+| Project | Approx. stars | Where it uses release-plz |
+| --- | ---: | --- |
+| [SurrealDB](https://github.com/surrealdb/surrealdb) | 32.2k | [workflow](https://github.com/surrealdb/surrealdb/blob/567832825a9ad660b002d96030c711a5f3d6c1e7/.github/workflows/reusable_publish_version.yml#L559) |
+| [tokei](https://github.com/XAMPPRocky/tokei) | 14.5k | [workflow](https://github.com/XAMPPRocky/tokei/blob/476bf2a70709e9a03de2d6c0875870ca09c251d2/.github/workflows/release-plz.yaml) |
+| [farm](https://github.com/farm-fe/farm) | 5.6k | [workflow](https://github.com/farm-fe/farm/blob/b4e02d43df294188749abafbe2f0da7692fffa4d/.github/workflows/release-plz.yaml) |
+| [aws-lambda-rust-runtime](https://github.com/aws/aws-lambda-rust-runtime) | 3.6k | [workflow](https://github.com/aws/aws-lambda-rust-runtime/blob/6b9ff4e7392b025c986510d86de9b3afe68701bb/.github/workflows/release-plz.yml#L28) |
+| [crux](https://github.com/redbadger/crux) | 2.6k | [release script](https://github.com/redbadger/crux/blob/72ae93a4fe15011df93a251707af439771b3be12/scripts/release-pr.sh) |
+| [cargo-generate](https://github.com/cargo-generate/cargo-generate) | 2.4k | [workflow](https://github.com/cargo-generate/cargo-generate/blob/859ecce6e1d49d9c84a9d7cc14eab130aba67a5a/.github/workflows/release-pr.yml) |
+| [pavex](https://github.com/LukeMathWalker/pavex) | 2.1k | [workflow](https://github.com/LukeMathWalker/pavex/blob/0e67806d7dcd990824161fcf5ddadca925c4a87c/.github/workflows/publish.yml) |
+| [windows-drivers-rs](https://github.com/microsoft/windows-drivers-rs) | 1.9k | [configuration](https://github.com/microsoft/windows-drivers-rs/blob/45811e309771f95d860c05a281efd42840a866cc/release-plz.toml) |
+| [octocrab](https://github.com/XAMPPRocky/octocrab) | 1.4k | [workflow](https://github.com/XAMPPRocky/octocrab/blob/6004d5059bf4dffa211780fd7db9710b744a03ab/.github/workflows/release-plz.yml) |
+| [daktilo](https://github.com/orhun/daktilo) | 1.2k | [workflow](https://github.com/orhun/daktilo/blob/9e2bb1a955d5f1e51f4b77ecef4f518ba66e06d5/.github/workflows/cd.yml#L13) |
 
 ## GitHub Action users
 


### PR DESCRIPTION
## What changed

- Replaces the plain popular-project bullet list with a sorted table.
- Adds approximate GitHub star counts for well-known release-plz users.
- Keeps links to the exact workflow/configuration locations where each project uses release-plz.

Addresses #1887.

## Verification

- `git diff --check`

I did not run the Docusaurus build because this checkout does not have `website/node_modules` installed and the change is Markdown-only.