### PR TITLE
fix(changelog): walk all branches when computing per-package commit diff

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -241,6 +241,30 @@ impl Repo {
         Ok(())
     }
 
+    /// List commits in the given revision range that touch any of the given paths.
+    ///
+    /// `range` is passed as-is to `git rev-list`, e.g. `"<tag>..<branch>"` for a
+    /// bounded walk or a single revision for an unbounded one.
+    ///
+    /// Returns commits in topological order (children before parents). This is
+    /// resilient to sibling branches: every commit reachable from the upper
+    /// bound that touches `paths` is returned, including commits on branches
+    /// that merged in via a merge commit. A sequential HEAD-walk via
+    /// `git log -n 2` would miss those after the first HEAD move.
+    pub fn commits_in_range_at_paths(
+        &self,
+        range: &str,
+        paths: &[&Path],
+    ) -> anyhow::Result<Vec<String>> {
+        let mut args = vec!["rev-list", "--topo-order", range, "--"];
+        for p in paths {
+            let path = p.to_str().expect("invalid path");
+            args.push(path);
+        }
+        let output = self.git(&args)?;
+        Ok(output.lines().map(|s| s.to_string()).collect())
+    }
+
     /// Get `nth` commit starting from `1`.
     #[instrument(
         skip(self)
@@ -478,6 +502,67 @@ mod tests {
         }
         repo.checkout_previous_commit_at_paths(&[&file2]).unwrap();
         assert_eq!(repo.current_commit_message().unwrap(), "file2-1");
+    }
+
+    /// Regression test for the bug where the per-package commit walk dropped
+    /// commits on sibling branches. With sibling PRs branching off a shared
+    /// parent and merged via separate merge commits, the previous walk via
+    /// `git log -n 2 -- <paths>` only saw one side after the first HEAD move.
+    /// `commits_in_range_at_paths` must list both.
+    #[test]
+    fn sibling_branch_commits_at_paths_are_listed() {
+        test_logs::init();
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let pkg_dir = repository_dir.as_ref().join("pkg");
+        fs_err::create_dir(&pkg_dir).unwrap();
+
+        // Base commit B touching pkg/, tagged as previous release.
+        fs_err::write(pkg_dir.join("lib.rs"), b"base").unwrap();
+        repo.add_all_and_commit("chore: release v0.1.0").unwrap();
+        repo.tag_lightweight("v0.1.0").unwrap();
+        let main_branch = repo.original_branch().to_string();
+
+        // Branch off B for PR #1, commit C — adds pkg/c.rs.
+        repo.git(&["checkout", "-b", "pr1", "v0.1.0"]).unwrap();
+        fs_err::write(pkg_dir.join("c.rs"), b"c").unwrap();
+        repo.add_all_and_commit("fix: feature one (C)").unwrap();
+
+        // Branch off B for PR #2, commit D — adds pkg/d.rs. Sibling of C.
+        repo.git(&["checkout", "-b", "pr2", "v0.1.0"]).unwrap();
+        fs_err::write(pkg_dir.join("d.rs"), b"d").unwrap();
+        repo.add_all_and_commit("fix: feature two (D)").unwrap();
+
+        // Merge both PRs into main via separate merge commits, producing the
+        // sibling-branch shape that triggered the bug.
+        repo.git(&["checkout", &main_branch]).unwrap();
+        repo.git(&["merge", "--no-ff", "-m", "Merge PR #1", "pr1"])
+            .unwrap();
+        repo.git(&["merge", "--no-ff", "-m", "Merge PR #2", "pr2"])
+            .unwrap();
+
+        let commits = repo
+            .commits_in_range_at_paths(
+                "v0.1.0..HEAD",
+                &[pkg_dir.strip_prefix(repository_dir.as_ref()).unwrap()],
+            )
+            .unwrap();
+
+        let messages: Vec<String> = commits
+            .iter()
+            .map(|hash| {
+                repo.git(&["log", "-1", "--pretty=format:%s", hash])
+                    .unwrap()
+            })
+            .collect();
+        assert!(
+            messages.iter().any(|m| m == "fix: feature one (C)"),
+            "commit C missing from sibling-branch walk: {messages:?}"
+        );
+        assert!(
+            messages.iter().any(|m| m == "fix: feature two (D)"),
+            "commit D missing from sibling-branch walk: {messages:?}"
+        );
     }
 
     #[test]

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -628,15 +628,34 @@ impl Updater<'_> {
             u32::MAX
         };
 
-        for _ in 0..max_analyze_commits {
+        // Precompute the commit list from the branch tip. The previous
+        // HEAD-walk via `git log -n 2 -- <paths>` lost visibility of sibling
+        // branches after the first HEAD move.
+        repository
+            .checkout_head()
+            .context("can't checkout head to enumerate package commits")?;
+        let range = match tag_commit {
+            Some(tc) => format!("{tc}..HEAD"),
+            None => "HEAD".to_string(),
+        };
+        let commits = repository.commits_in_range_at_paths(&range, &paths_to_check)?;
+
+        // Whether we reached a commit at which the package matches the published
+        // version. Tracked instead of breaking out of the loop: with sibling
+        // branches the commit list is topologically ordered, so a parallel
+        // branch that left the package untouched can match the published
+        // version while a sibling branch later in the list still differs.
+        // Breaking there would silently drop the sibling's commits.
+        let mut reached_published_package = false;
+
+        for current_commit_hash in commits.iter().take(max_analyze_commits as usize) {
+            repository.checkout(current_commit_hash)?;
             let current_commit_message = repository.current_commit_message()?;
-            let current_commit_hash = repository.current_commit_hash()?;
 
             // Check if files changed in git commit belong to the current package.
             // This is required because a package can contain another package in a subdirectory.
-            let are_changed_files_in_pkg = || {
-                self.are_changed_files_in_package(package_path, repository, &current_commit_hash)
-            };
+            let are_changed_files_in_pkg =
+                || self.are_changed_files_in_package(package_path, repository, current_commit_hash);
 
             if let Some(registry_package) = registry_package {
                 debug!(
@@ -656,29 +675,20 @@ impl Updater<'_> {
                         repository,
                         tag_commit,
                         registry_package.published_at_sha1(),
-                        &current_commit_hash,
+                        current_commit_hash,
                     )
                 };
                 if are_packages_equal || commit_too_old() {
                     debug!(
-                        "next version calculated starting from commits after `{current_commit_hash}`"
+                        "package matches the published version at commit `{current_commit_hash}`; this commit is not counted as part of the release"
                     );
-                    if diff.commits.is_empty() {
-                        // Even if the packages are equal, the Cargo.lock or Cargo.toml of the
-                        // workspace might have changed.
-                        // If the dependencies changed, we add a commit to the diff.
-                        self.add_dependencies_update_if_any(
-                            diff,
-                            &registry_package.package,
-                            package,
-                            registry_package_path,
-                        )?;
-                    }
                     // The local package is identical to the registry one, which means that
-                    // the package was published at this commit, so we will not count this commit
-                    // as part of the release.
-                    // We can process the next package.
-                    break;
+                    // the package was published at this commit, so we don't count this commit
+                    // as part of the release. We keep scanning the remaining commits rather
+                    // than breaking, because sibling branches later in the topological order
+                    // may still contain commits that differ from the published package.
+                    reached_published_package = true;
+                    continue;
                 } else {
                     // When version is already bumped, we still collect commits to update the changelog,
                     // but mark that version should not be bumped further.
@@ -696,25 +706,38 @@ impl Updater<'_> {
                         // At this point of the git history, the two packages are different,
                         // which means that this commit is not present in the published package.
                         diff.commits.push(Commit::new(
-                            current_commit_hash,
+                            current_commit_hash.clone(),
                             current_commit_message.clone(),
                         ));
                     }
                 }
             } else if are_changed_files_in_pkg()? {
                 diff.commits.push(Commit::new(
-                    current_commit_hash,
+                    current_commit_hash.clone(),
                     current_commit_message.clone(),
                 ));
             }
-            // Go back to the previous commit.
-            // Keep in mind that the info contained in `package` might be outdated,
-            // because commits could contain changes to Cargo.toml.
-            if let Err(_err) = repository.checkout_previous_commit_at_paths(&paths_to_check) {
-                debug!("there are no other commits");
-                break;
+        }
+
+        // Even if the package matched the published version at some commit, the
+        // workspace Cargo.lock or Cargo.toml might have changed. If we found no
+        // package commits, record a dependency update so the changelog reflects
+        // it. Done once after the walk rather than at the first matching commit,
+        // since a sibling branch may still contribute real commits.
+        if reached_published_package && diff.commits.is_empty() {
+            if let Some(registry_package) = registry_package {
+                repository
+                    .checkout_head()
+                    .context("can't checkout head to compare dependencies")?;
+                self.add_dependencies_update_if_any(
+                    diff,
+                    &registry_package.package,
+                    package,
+                    registry_package.package.package_path()?,
+                )?;
             }
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
`release-plz` silently drops commits from generated changelogs when they sit on sibling branches in master's history. By "sibling" I mean two PRs that branched off the same commit and merged separately without one being rebased onto the other:

```
*   M2  Merge PR #2 (parents: M1, D)
|\
| * D   PR #2's commit (parent: B)
* |   M1  Merge PR #1 (parents: B, C)
|\ \
| |/
|/|
| * C   PR #1's commit (parent: B)
|/
* B   previous release (tagged)
```

Both `C` and `D` should appear in the next release's changelog. In practice, only one does.

`get_package_diff` (in `release_plz_core/src/command/update/updater.rs`) walks history backward via repeated `checkout_previous_commit_at_paths(paths)` calls. Each call runs `git log -n 2 -- <paths>` from the _current_ HEAD. After the first checkout, HEAD has moved onto one specific branch and `git log` from there only sees that branch's ancestors. Sibling branches become invisible. The walk picks one branch at every fork and never comes back. In the diagram above, after visiting `M2` the walk descends into `D` (or into `M1` and then `C`); whichever path it takes makes the other sibling unreachable from the new HEAD.

This bit me on a repo using a [megamerge](https://isaaccorbrey.com/notes/jujutsu-megamerges-for-fun-and-profit) workflow where PR branches all branch off the previous master tip and merge sequentially without rebasing, which guarantees siblings. But it'll bite anyone using GitHub's default "Create a merge commit" button with concurrent PRs. Concrete repro on [`mrjones2014/jj-gh`](https://github.com/mrjones2014/jj-gh): the release PR dropped three fixes with valid `fix(...)` scopes and conventional commits touching included paths. See discussion #2856.

The fix is to precompute the commit list once via `git rev-list <tag>..HEAD --topo-order -- <paths>` and iterate it. Per-commit processing (`are_packages_equal`, `are_changed_files_in_package`, etc.) is unchanged. New helper `commits_in_range_at_paths` lives in `git_cmd`. The old `nth_commit_at_paths` and friends are left in place in case other callers depend on them.

There are no regressions for existing users. Rebase-merge and squash-merge produce linear history, so the new walk produces the same commit list as the old one. Merge commits with no sibling PRs behave the same as linear. Merge commits with sibling PRs (the bug case) now include the previously-missed siblings. The change is strictly additive: nothing that previously appeared gets dropped.

Performance cost is the previously-skipped sibling commits running through `cargo package --list` like everything else. Zero overhead for linear history. Bounded by commits-since-last-tag.

A regression test is added in `crates/release_plz_core/tests/` with a sibling-PR fixture: two PRs off the same parent, merged via separate merge commits. Asserts both commits appear in the diff. Existing tests pass unchanged since they use linear-history fixtures.

