### PR TITLE
fix: force CARGO_TERM_QUIET=false when invoking cargo

### DIFF
--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -18,7 +18,16 @@ pub struct CargoRegistry {
 
 fn cargo_cmd() -> Command {
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    Command::new(cargo)
+    let mut cmd = Command::new(cargo);
+    // release-plz parses cargo's stdout/stderr to drive its own logic
+    // (e.g. it scans `cargo publish` output for the "Uploading" marker to
+    // detect a successful upload, see `release.rs`). If the user has
+    // `[term] quiet = true` in their cargo config, cargo silences those
+    // markers and release-plz fails with confusing errors. Force quiet mode
+    // off; the env var takes precedence over the config file.
+    // See https://github.com/release-plz/release-plz/issues/2821
+    cmd.env("CARGO_TERM_QUIET", "false");
+    cmd
 }
 
 pub fn run_cargo(root: &Utf8Path, args: &[&str]) -> anyhow::Result<CmdOutput> {
@@ -188,4 +197,31 @@ pub async fn wait_until_published(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for <https://github.com/release-plz/release-plz/issues/2821>
+    ///
+    /// release-plz parses cargo's output to detect package files, the "Uploading"
+    /// marker on `cargo publish`, etc. If a user has `[term] quiet = true` in their
+    /// cargo config, those markers disappear and release-plz fails with confusing
+    /// errors. `cargo_cmd()` must always set `CARGO_TERM_QUIET=false` so the env var
+    /// (which takes precedence over the config file) overrides any user config.
+    #[test]
+    fn cargo_cmd_disables_term_quiet() {
+        let cmd = cargo_cmd();
+        let env_value = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("CARGO_TERM_QUIET"))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned());
+        assert_eq!(
+            env_value.as_deref(),
+            Some("false"),
+            "cargo_cmd() must set CARGO_TERM_QUIET=false to override `[term] quiet = true` in user cargo config"
+        );
+    }
 }


### PR DESCRIPTION
Closes #2821.

## Problem

When the user has `[term] quiet = true` in their cargo config (`~/.cargo/config.toml` or a workspace `.cargo/config.toml`), cargo silences the output that release-plz parses to drive its own logic. The most damaging instance is in `release.rs`: after `cargo publish`, release-plz checks `output.stderr.contains("Uploading")` to confirm a successful upload. Under `quiet = true`, that line is never emitted, so release-plz falls into the failure branch and bails with no useful error — exactly the symptom the reporter described ("Every run of release-plz in the workspace would get one crate further and then fail with no error message").

The reporter's manual workaround was `CARGO_TERM_QUIET=false release-plz release`. This PR bakes that in.

## Fix

`cargo_cmd()` is the single constructor for every cargo subprocess release-plz spawns (`run_cargo`, `run_cargo_with_env`, `run_cargo_info` all go through it). Setting `CARGO_TERM_QUIET=false` there is sufficient: the env var takes precedence over the config file, so the user's `quiet = true` no longer suppresses output release-plz depends on.

`cargo-semver-checks` is invoked directly via `Command::new("cargo-semver-checks")` (it's a separate binary, not a cargo subcommand) and is unaffected by this change — it doesn't read `CARGO_TERM_*` and release-plz doesn't string-match its output.

## Test

Added a regression unit test (`cargo::tests::cargo_cmd_disables_term_quiet`) that asserts the constructed `Command` carries `CARGO_TERM_QUIET=false`. Verified the test fails when the env line is removed and passes once it's restored.

```
$ cargo test -p release_plz_core --lib cargo::tests::
running 1 test
test cargo::tests::cargo_cmd_disables_term_quiet ... ok
```

`cargo fmt` and `cargo clippy --no-deps -p release_plz_core -- -D warnings` clean.