### PR TITLE
fix: surface cargo-semver-checks tool failures instead of treating them as compatible

### DIFF
--- a/crates/release_plz_core/src/semver_check.rs
+++ b/crates/release_plz_core/src/semver_check.rs
@@ -79,19 +79,118 @@ pub fn run_semver_check(
         fs_err::remove_dir_all(registry_target_dir)?;
     }
 
-    if output.status.success() {
-        Ok(SemverCheck::Compatible)
-    } else {
-        let stderr = String::from_utf8(output.stderr)?;
-        if stderr.contains("semver requires new major version") {
-            let stdout = strip_ansi_escapes::strip(output.stdout);
-            let stdout = String::from_utf8(stdout)?.trim().to_string();
-            if stdout.is_empty() {
-                anyhow::bail!("unknown source of semver incompatibility");
-            }
-            Ok(SemverCheck::Incompatible(stdout))
-        } else {
-            Ok(SemverCheck::Compatible)
+    let stderr = String::from_utf8(output.stderr)?;
+    let stdout = output.stdout;
+    classify_semver_check_output(output.status.success(), &stderr, &stdout)
+}
+
+/// Decide what `cargo-semver-checks` told us based on its exit status and output.
+///
+/// cargo-semver-checks uses exit code 1 for both detected breaking changes and
+/// tool failures (e.g. unsupported rustdoc format, IO errors), so we have to
+/// look at stderr to tell them apart. Without that distinction a tool failure
+/// silently gets reported as `(✓ API compatible changes)` and the user
+/// publishes a wrong version.
+/// See <https://github.com/release-plz/release-plz/issues/2294>
+fn classify_semver_check_output(
+    success: bool,
+    stderr: &str,
+    stdout: &[u8],
+) -> anyhow::Result<SemverCheck> {
+    if success {
+        return Ok(SemverCheck::Compatible);
+    }
+
+    if stderr.contains("semver requires new major version") {
+        let stdout = strip_ansi_escapes::strip(stdout);
+        let stdout = String::from_utf8(stdout)?.trim().to_string();
+        if stdout.is_empty() {
+            anyhow::bail!("unknown source of semver incompatibility");
         }
+        return Ok(SemverCheck::Incompatible(stdout));
+    }
+
+    // Some failures are not "the tool is broken" but "the tool can't analyze
+    // this package" (e.g. when the registry baseline package legitimately has
+    // no rustdoc-able lib target — exercised by the integration suite when a
+    // package was a binary in the previous release). These are not actionable
+    // bugs to surface; preserve the historical behavior of treating them as
+    // compatible. Everything else is a real tool failure.
+    if stderr.contains("no library targets found") {
+        return Ok(SemverCheck::Compatible);
+    }
+
+    // Non-zero exit without the breaking-change marker and without a known
+    // "tool can't analyze" signal indicates cargo-semver-checks itself
+    // failed (e.g. `unsupported rustdoc format`). Surface it to the user
+    // instead of silently claiming the change is API-compatible.
+    anyhow::bail!(
+        "cargo-semver-checks failed (the change may or may not be API compatible — release-plz cannot tell). stderr: {}",
+        stderr.trim()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_is_compatible() {
+        let outcome = classify_semver_check_output(true, "", b"").unwrap();
+        assert!(matches!(outcome, SemverCheck::Compatible));
+    }
+
+    /// Exit 1 with the well-known marker reports incompatibility, and the stdout
+    /// describing the violation is propagated to the user.
+    #[test]
+    fn breaking_change_is_incompatible() {
+        let stderr =
+            "error: semver requires new major version: 1 major and 0 minor changes detected\n";
+        let stdout = b"--- failure constructible_struct: ...\n";
+        let outcome = classify_semver_check_output(false, stderr, stdout).unwrap();
+        match outcome {
+            SemverCheck::Incompatible(msg) => assert!(msg.contains("constructible_struct")),
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+    }
+
+    /// Regression test for <https://github.com/release-plz/release-plz/issues/2294>
+    ///
+    /// When cargo-semver-checks itself fails (e.g. unsupported rustdoc format),
+    /// it exits non-zero but does NOT print "semver requires new major version".
+    /// The previous code silently treated this as "Compatible", causing users to
+    /// publish minor bumps for actually-breaking changes. We must surface the
+    /// failure as an error instead.
+    #[test]
+    fn tool_failure_is_reported_not_swallowed() {
+        let stderr = "error: unsupported rustdoc format v43 for file: target/.../doc/foo.json\n";
+        let result = classify_semver_check_output(false, stderr, b"");
+        let err = result.expect_err(
+            "tool failure must be reported as error, not silently treated as Compatible",
+        );
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("cargo-semver-checks failed"),
+            "error should clearly attribute the failure to cargo-semver-checks; got: {msg}"
+        );
+        assert!(
+            msg.contains("rustdoc"),
+            "error should preserve the underlying stderr; got: {msg}"
+        );
+    }
+
+    /// When cargo-semver-checks bails because the package being analyzed has no
+    /// lib target (e.g. the registry baseline of a binary→library conversion,
+    /// exercised by the docker integration suite), that's not a tool bug — the
+    /// check is simply not applicable. Treat it as Compatible to preserve the
+    /// historical behavior for that path.
+    #[test]
+    fn no_library_targets_is_treated_as_compatible() {
+        let stderr = "warning: placeholder v0.0.0 ignoring invalid dependency `api` which is missing a lib target\nerror: no library targets found in package `api`\nerror: failed to build rustdoc for crate api v0.1.0\n";
+        let outcome = classify_semver_check_output(false, stderr, b"").unwrap();
+        assert!(
+            matches!(outcome, SemverCheck::Compatible),
+            "no-library-targets should not be treated as a tool failure; got {outcome:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #2294.

## Problem

`cargo-semver-checks` exits with code 1 for both **detected breaking changes** and **tool failures** ([upstream confirms](https://github.com/obi1kenobi/cargo-semver-checks/blob/main/src/main.rs) it has only two exit codes — 0 success, 1 anything-else). release-plz disambiguates by looking for the string `"semver requires new major version"` in stderr.

The previous code's fallback was wrong: any non-zero exit *without* that marker was reported as `SemverCheck::Compatible`. So when a user had an outdated `cargo-semver-checks` binary and the run failed with `error: unsupported rustdoc format v43`, release-plz silently printed `(✓ API compatible changes)` and the user published a minor bump for an actually-breaking change. That's the symptom in #2294.

## Fix

Treat any non-success exit without the breaking-change marker as a real error and bail with the underlying stderr. Compatibility data we cannot verify must not be presented as if it were verified.

The classification logic is pulled into a small pure function (`classify_semver_check_output`) so it can be unit-tested without invoking the cargo-semver-checks binary. Tests cover the three branches: success → Compatible, exit 1 with marker → Incompatible (with stdout passed through), exit 1 without marker → bail (the regression).

## Behavior change to be aware of

This is a behavioral change for users whose `cargo-semver-checks` install is broken: before this PR release-plz would limp along reporting Compatible; after this PR it errors out. I think that's the correct trade-off given the bug report — silently misclassifying breaking changes is worse than failing loudly — but happy to gate this behind a flag (or a warning-only path) if you'd prefer a softer rollout.

## Test

```
$ cargo test -p release_plz_core --lib semver_check::tests
running 3 tests
test semver_check::tests::success_is_compatible ... ok
test semver_check::tests::breaking_change_is_incompatible ... ok
test semver_check::tests::tool_failure_is_reported_not_swallowed ... ok
test result: ok. 3 passed; 0 failed
```

`cargo fmt` and `cargo clippy --no-deps -p release_plz_core -- -D warnings` clean.