### PR TITLE
fix: use new PR title as commit message when updating release PR

### DIFF
--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -335,10 +335,16 @@ async fn update_pr(
             repository.original_branch()
         )
     })?;
+    // Use `new_pr.title` (not `opened_pr.title`) as the commit message: when a
+    // breaking change is pushed onto an existing release PR, the new title
+    // reflects the bumped version (e.g. v0.32.0). Using `opened_pr.title` here
+    // would commit with the stale title (v0.31.2) while the PR title gets
+    // edited to the new one a few lines below — leaving commit and PR title
+    // inconsistent. See https://github.com/release-plz/release-plz/issues/2849
     if git_client.forge == ForgeType::Github {
-        github_force_push(git_client, opened_pr, repository).await?;
+        github_force_push(git_client, opened_pr, repository, &new_pr.title).await?;
     } else {
-        force_push(opened_pr, repository)?;
+        force_push(opened_pr, repository, &new_pr.title)?;
     }
     let pr_edit = {
         let mut pr_edit = PrEdit::new();
@@ -417,8 +423,8 @@ fn reset_branch(
     Ok(())
 }
 
-fn force_push(pr: &GitPr, repository: &Repo) -> anyhow::Result<()> {
-    add_changes_and_commit(repository, &pr.title)?;
+fn force_push(pr: &GitPr, repository: &Repo, commit_message: &str) -> anyhow::Result<()> {
+    add_changes_and_commit(repository, commit_message)?;
     repository.force_push(pr.branch())?;
     Ok(())
 }
@@ -427,6 +433,7 @@ async fn github_force_push(
     client: &GitClient,
     pr: &GitPr,
     repository: &Repo,
+    commit_message: &str,
 ) -> anyhow::Result<()> {
     let tmp_release_branch = format!("{}-tmp-{}", pr.branch(), rand::random::<u32>());
     repository.checkout_new_branch(&tmp_release_branch)?;
@@ -439,8 +446,8 @@ async fn github_force_push(
     // - If we revert the last commit of the release PR branch, GitHub will close the release PR
     //   because the branch is the same as the default branch. So we can't revert the latest release-plz commit and push the new one.
     // To learn more, see https://github.com/release-plz/release-plz/issues/1487
-    let sha =
-        github_create_release_branch(client, repository, &tmp_release_branch, &pr.title).await?;
+    let sha = github_create_release_branch(client, repository, &tmp_release_branch, commit_message)
+        .await?;
 
     let force_push_result =
         execute_github_force_push(client, pr, repository, &tmp_release_branch, &sha).await;


### PR DESCRIPTION
Closes #2849.

## Problem

When release-plz finds an already-open release PR and a new commit changes the bump (e.g. a `feat!` arrives, pushing v0.31.2 → v0.32.0), `update_pr` does two things:

1. Force-pushes a new commit on the PR branch with the bumped contents.
2. Edits the PR via `PrEdit::with_title(new_pr.title)` so the title reflects the new version.

The bug: step 1 builds the commit message from `opened_pr.title` (the *old* title, "chore: release v0.31.2"), while step 2 updates the PR title to `new_pr.title` ("chore: release v0.32.0"). Result: PR title and commit message disagree, exactly the symptom in the linked vpxtool example.

```text
release_pr/mod.rs   force_push    -> uses pr.title (== opened_pr.title, stale)
release_pr/mod.rs   github_force_push -> uses pr.title (== opened_pr.title, stale)
release_pr/mod.rs   update_pr (later) -> edits PR to new_pr.title
```

## Fix

Pass `new_pr.title` down to `force_push` / `github_force_push`. Both functions now take an explicit `commit_message: &str`; `update_pr` is the only caller and now feeds it `&new_pr.title`. After the change the commit and PR title are consistent.

This also matches what the new-PR path already does: `create_pr` calls `github_create_release_branch(..., &pr.title)` where `pr` is the freshly-built `Pr`, never a stale opened-PR title.

## Tests

The behavior is exercised end-to-end by the docker-backed `release_plz/tests/all/release_pr.rs` suite. I don't have a docker environment locally, so I haven't added a regression test there — happy to add one if you can point me at the right pattern, or if you'd prefer I'll run the suite in a CI fork. The diff itself is mechanical (one parameter, two callsites) and does not change any other behavior.

`cargo build`, `cargo clippy --no-deps -p release_plz_core -- -D warnings`, `cargo fmt --check` all clean on the fix.