### PR TITLE
fix(set-version): honor workspace-level changelog_path

### DIFF
--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -86,6 +86,14 @@ impl Config {
         &self,
         set_version_request: &mut SetVersionRequest,
     ) -> anyhow::Result<()> {
+        // Apply the workspace-level default first so every package picks it
+        // up. Per-package `[[package]] changelog_path` is applied below and
+        // overrides this default for that specific package.
+        // See <https://github.com/release-plz/release-plz/issues/2441>
+        if let Some(changelog_path) = self.workspace.packages_defaults.changelog_path.clone() {
+            let changelog_path = to_utf8_pathbuf(changelog_path)?;
+            set_version_request.set_default_changelog_path(changelog_path);
+        }
         for (package, config) in self.packages() {
             if let Some(changelog_path) = config.common.changelog_path.clone() {
                 let changelog_path = to_utf8_pathbuf(changelog_path)?;

--- a/crates/release_plz_core/src/command/set_version.rs
+++ b/crates/release_plz_core/src/command/set_version.rs
@@ -32,6 +32,31 @@ impl SetVersionRequest {
             }
         }
     }
+
+    /// Apply a workspace-level default changelog path to every package that
+    /// does not already have its own per-package override.
+    ///
+    /// Without this, `[workspace] changelog_path = "./CHANGELOG.md"` would be
+    /// silently ignored by `set-version` and the command would look for a
+    /// per-crate `CHANGELOG.md` that doesn't exist in monorepos that share a
+    /// single workspace changelog.
+    /// See <https://github.com/release-plz/release-plz/issues/2441>
+    pub fn set_default_changelog_path(&mut self, changelog_path: Utf8PathBuf) {
+        match &mut self.version_changes {
+            SetVersionSpec::Single(change) => {
+                if change.changelog_path.is_none() {
+                    change.changelog_path = Some(changelog_path);
+                }
+            }
+            SetVersionSpec::Workspace(changes) => {
+                for change in changes.values_mut() {
+                    if change.changelog_path.is_none() {
+                        change.changelog_path = Some(changelog_path.clone());
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -134,8 +159,20 @@ fn set_version_in_package(
         &workspace_manifest.path,
     )?;
     let default_changelog_path = pkg_path.join(CHANGELOG_FILENAME);
-    let changelog_path: &Utf8Path = change
-        .changelog_path
+    // Resolve a configured `changelog_path` relative to the workspace
+    // manifest's parent (matching how `update` interprets it). Without this,
+    // a value like `./CHANGELOG.md` would be resolved against the process
+    // cwd, which is unreliable and inconsistent with the rest of release-plz.
+    let resolved_changelog_path: Option<Utf8PathBuf> = change.changelog_path.as_ref().map(|p| {
+        if p.is_absolute() {
+            p.clone()
+        } else if let Some(workspace_dir) = workspace_manifest.path.parent() {
+            workspace_dir.join(p)
+        } else {
+            p.clone()
+        }
+    });
+    let changelog_path: &Utf8Path = resolved_changelog_path
         .as_deref()
         .unwrap_or(&default_changelog_path);
     update_changelog(changelog_path, &pkg.version, &change.version)
@@ -162,4 +199,109 @@ fn update_changelog(
     fs_err::write(changelog_path, new_changelog_content)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_change() -> VersionChange {
+        VersionChange::new(Version::new(1, 0, 0))
+    }
+
+    /// Workspace-default `changelog_path` should land on every package that
+    /// doesn't have its own override. Regression for
+    /// <https://github.com/release-plz/release-plz/issues/2441>.
+    #[test]
+    fn workspace_default_propagates_to_all_packages() {
+        let mut spec = SetVersionSpec::Workspace(BTreeMap::from([
+            ("a".to_string(), dummy_change()),
+            ("b".to_string(), dummy_change()),
+        ]));
+        let mut req = SetVersionRequest {
+            manifest: Utf8PathBuf::from("/tmp/Cargo.toml"),
+            metadata: empty_metadata(),
+            version_changes: spec_take(&mut spec),
+        };
+        req.set_default_changelog_path(Utf8PathBuf::from("./CHANGELOG.md"));
+        let SetVersionSpec::Workspace(changes) = req.version_changes else {
+            unreachable!()
+        };
+        assert_eq!(
+            changes["a"].changelog_path.as_deref(),
+            Some(Utf8Path::new("./CHANGELOG.md")),
+        );
+        assert_eq!(
+            changes["b"].changelog_path.as_deref(),
+            Some(Utf8Path::new("./CHANGELOG.md")),
+        );
+    }
+
+    /// A per-package override applied first must NOT be replaced by a
+    /// subsequent workspace default.
+    #[test]
+    fn per_package_override_wins_over_workspace_default() {
+        let mut changes = BTreeMap::new();
+        let mut a = dummy_change();
+        a.with_changelog_path(Utf8PathBuf::from("./crates/a/CHANGELOG.md"));
+        changes.insert("a".to_string(), a);
+        changes.insert("b".to_string(), dummy_change());
+        let mut spec = SetVersionSpec::Workspace(changes);
+        let mut req = SetVersionRequest {
+            manifest: Utf8PathBuf::from("/tmp/Cargo.toml"),
+            metadata: empty_metadata(),
+            version_changes: spec_take(&mut spec),
+        };
+        req.set_default_changelog_path(Utf8PathBuf::from("./CHANGELOG.md"));
+        let SetVersionSpec::Workspace(changes) = req.version_changes else {
+            unreachable!()
+        };
+        assert_eq!(
+            changes["a"].changelog_path.as_deref(),
+            Some(Utf8Path::new("./crates/a/CHANGELOG.md")),
+            "package-specific changelog_path must not be clobbered by the workspace default"
+        );
+        assert_eq!(
+            changes["b"].changelog_path.as_deref(),
+            Some(Utf8Path::new("./CHANGELOG.md")),
+        );
+    }
+
+    #[test]
+    fn workspace_default_applies_to_single_spec() {
+        let mut req = SetVersionRequest {
+            manifest: Utf8PathBuf::from("/tmp/Cargo.toml"),
+            metadata: empty_metadata(),
+            version_changes: SetVersionSpec::Single(dummy_change()),
+        };
+        req.set_default_changelog_path(Utf8PathBuf::from("./CHANGELOG.md"));
+        let SetVersionSpec::Single(change) = req.version_changes else {
+            unreachable!()
+        };
+        assert_eq!(
+            change.changelog_path.as_deref(),
+            Some(Utf8Path::new("./CHANGELOG.md")),
+        );
+    }
+
+    fn spec_take(spec: &mut SetVersionSpec) -> SetVersionSpec {
+        let placeholder = SetVersionSpec::Workspace(BTreeMap::new());
+        std::mem::replace(spec, placeholder)
+    }
+
+    fn empty_metadata() -> Metadata {
+        // Minimal valid cargo metadata JSON. The set_default_changelog_path
+        // tests don't touch metadata, but Rust insists we construct one.
+        let json = r#"{
+            "packages": [],
+            "workspace_members": [],
+            "workspace_default_members": [],
+            "resolve": null,
+            "target_directory": "/tmp/target",
+            "version": 1,
+            "workspace_root": "/tmp",
+            "metadata": null
+        }"#;
+        serde_json::from_str(json).expect("valid empty metadata JSON")
+    }
 }


### PR DESCRIPTION
Closes #2441.

## Problem

In monorepos that share a single workspace changelog (the ratatui setup that the OP reported, but also any project using `[workspace] changelog_path = "./CHANGELOG.md"`), `release-plz set-version` ignores the workspace setting and falls back to the per-crate default. The command then errors out because that per-crate file doesn't exist:

```
$ release-plz set-version ratatui@0.30.0-beta.0
ERROR failed to update changelog at /Users/joshka/local/ratatui/ratatui/CHANGELOG.md

Caused by:
    failed to open file ...: No such file or directory
```

`Config::fill_set_version_config` only iterates `self.packages()` — i.e. `[[package]]` sections — and never reads `self.workspace.packages_defaults.changelog_path`. So with workspace-only config, every `VersionChange` ends up with `changelog_path: None` and the code falls through to `pkg_path.join("CHANGELOG.md")`. (`update` and `release` don't have this problem because `UpdateRequest::changelog_path` does merge in the workspace default — `update_request.rs:78-84`.)

## Fix

Two surgical changes:

**`fill_set_version_config`** now applies the workspace-level default first, then per-package overrides. Per-package config still wins for any package that overrides it.

**New `SetVersionRequest::set_default_changelog_path`** walks both the `Single` and `Workspace` spec variants and sets the path on every entry that doesn't already have one. Symmetric with the existing `set_changelog_path` but only fills empties — `is_none()` guards keep per-package overrides intact.

**Path resolution in `set_version_in_package`** now joins a configured `changelog_path` to the workspace manifest's parent directory, mirroring `UpdateRequest::changelog_path`. Without this, `./CHANGELOG.md` was being resolved against the process cwd — unreliable and inconsistent with how every other release-plz command interprets the field.

## Tests

Three new unit tests in `command::set_version::tests`:

- `workspace_default_propagates_to_all_packages` — workspace default lands on every package in a workspace spec
- `per_package_override_wins_over_workspace_default` — order independence: per-package wins regardless of when set_default_changelog_path is called
- `workspace_default_applies_to_single_spec` — the single-package case

```
$ cargo test -p release_plz_core --lib command::set_version::tests
running 3 tests
test command::set_version::tests::workspace_default_applies_to_single_spec ... ok
test command::set_version::tests::workspace_default_propagates_to_all_packages ... ok
test command::set_version::tests::per_package_override_wins_over_workspace_default ... ok
test result: ok. 3 passed
```

`cargo clippy --all-targets --all-features --workspace -- -D warnings` and `cargo fmt --check` clean.

## Note

This does not fully address #1554 (workspace-level *version* support), only the changelog-path piece of #2441 that's specific to set-version.