### PR TITLE
docs(faq): explain why empty commits don't trigger a version bump

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -83,3 +83,21 @@ Release-plz uses the [next_version](https://crates.io/crates/next_version)
 crate to determine the next version.
 Please read the [documentation](https://docs.rs/next_version/latest/next_version/),
 and open an issue if it's not clear enough.
+
+### Empty commits don't trigger a bump
+
+Release-plz detects releaseable changes by diffing the local package against
+the registry version, not by parsing every commit message in isolation. An
+empty commit (e.g. `git commit --allow-empty -m 'feat!: force major bump'`)
+leaves the package contents identical to the registry version, so release-plz
+sees no changes to release and does not bump the version.
+
+If you need to force a version, two reliable options:
+
+1. **Make a real change.** Even a one-line edit (e.g. updating the README) is
+   enough to make the package differ from the registry copy and let
+   release-plz pick up the conventional-commit footer.
+2. **Use `release-plz set-version`.** Run
+   `release-plz set-version <package>@<version>` to bump the version
+   directly, commit the change, and release-plz will release the new version
+   when the PR is merged.


### PR DESCRIPTION
Closes #2673.

The reporter ran `git commit --allow-empty -m 'feat!: force major version bump'` expecting release-plz to pick it up, and was surprised when only a real content change (a README edit) actually triggered the bump. @marcoieni explained why in the issue thread:

> release-plz compares the two packages and detects that they are the same so it doesn't bump the version.

The reporter then asked:

> Maybe adding a note to https://release-plz.dev/docs/faq#release-plz-bumped-the-version-in-a-way-i-didnt-expect could be enough to close this?

@marcoieni said yes, PR welcome — that's this PR.

I added a subsection under the existing "Release-plz bumped the version in a way I didn't expect" entry. It states the cause concisely (release-plz diffs against the registry, not commit messages alone) and lists the two reliable workarounds:

1. Make any real content change so the package differs from the registry copy.
2. Use `release-plz set-version` to bump explicitly, then commit normally.

Pure docs change, no code touched.