### PR TITLE
docs(config): clarify pr_branch_prefix doesn't support template variables

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -533,6 +533,14 @@ Prefix for the release PR branch. By default, it's set to: `release-plz-`
 Before changing the release-plz branch you should close the old release PR.
 :::
 
+:::note
+Unlike [`pr_name`](#the-pr_name-field), `pr_branch_prefix` is treated as a
+literal string — Tera template variables such as `{{ package }}` are **not**
+substituted. Branches need stable names so release-plz can find the existing
+release PR across runs; templating per-package would also be ambiguous in
+multi-crate workspaces (which package would the variable resolve to?).
+:::
+
 #### The `pr_draft` field
 
 - If `true`, release-plz creates the release PR as a draft.


### PR DESCRIPTION
Refs #2000.

Users in #2000 and #1991 reasonably assumed Tera template variables work for \`pr_branch_prefix\` because they work for \`pr_name\`. The maintainer's stance from the issue thread:

> It's not a bug because it's not documented that you can substitute template variables.

> My main point for not supporting this is that if you are in a workspace with multiple packages, what should \`{{ package }}\` resolve to?

> You can (and we do) easily rename PR names. You can't do the same for branches.

This PR adds a \`:::note\` callout under the \`pr_branch_prefix\` field documenting the constraint and the rationale (stable branch name needed to find the existing release PR across runs; per-package templating ambiguous in multi-crate workspaces). The hope is users hit the docs before the issue tracker.

Pure docs change, 8 lines added, no code touched.