### PR TITLE
docs(set-version): document the release-PR workflow + run-on-main footgun

### DIFF
--- a/website/docs/usage/set-version.md
+++ b/website/docs/usage/set-version.md
@@ -20,3 +20,39 @@ You can use this command to quickly update the version of a package in case rele
 update to the version you intended, e.g.
 because you forgot to prefix a commit message with `feat:`.
 :::
+
+## Workflow: correcting a wrong version on an open release PR
+
+`set-version` is most useful **on the release PR branch**, not on `main`. The
+intended flow is:
+
+1. Check out the open release PR branch locally.
+2. Run `release-plz set-version <pkg>@<correct version>` from the workspace root.
+3. Commit the resulting `Cargo.toml` + `CHANGELOG.md` edits and push back to
+   the release PR branch.
+4. Let the existing release-plz workflow merge the PR as usual.
+
+This way the corrected version travels through the PR + merge path that the
+rest of release-plz already understands, instead of being committed straight
+to `main`.
+
+:::warning
+**Don't run `set-version` on `main` if you have a CI workflow that releases on
+push to `main`.** Doing so will commit a fully-formed version bump directly to
+`main`, which most release-plz workflows treat as "release this version now".
+The release will go out before any PR review, and any pre-release adjustments
+(e.g. extra commits you intended to land first) won't make it in.
+
+The release PR branch exists precisely so that the version + changelog edits
+can be staged, reviewed, and amended before publication. Use it.
+:::
+
+:::warning
+`set-version` rewrites the version of the **most recent changelog entry** —
+i.e. the `[Unreleased]` section if you've staged release-plz's normal output,
+or otherwise the topmost release entry. If you run it on a clean checkout
+where the previous release is already at the top of the changelog, it will
+edit *that* entry instead of preparing a new one. Always run `set-version` on
+a checkout that already has the in-flight release PR's changelog updates
+applied (i.e. the PR branch).
+:::


### PR DESCRIPTION
Closes #2555.

The reporter ran into a real footgun: \`set-version\` is most useful on the open release PR branch, but the docs only describe what the command does, never where in a workflow it's supposed to fit. They followed the only obvious path — running \`set-version\` on \`main\` — and:

1. It rewrote the *previous* release's changelog entry (because the in-flight release PR's changelog hadn't been applied locally).
2. The version-bump commit on \`main\` then triggered the auto-release CI before they could correct anything.

End result: a wrong release went out.

This PR adds a **Workflow** section to the existing \`set-version\` page describing the intended path:

1. Check out the open release PR branch locally.
2. Run \`set-version\` there.
3. Commit + push back to the PR branch.
4. Let release-plz's normal workflow merge the PR.

Plus two \`:::warning\` callouts that name the two failure modes by name — the run-on-main release-trigger footgun, and the rewrites-the-previous-changelog-entry footgun.

Pure docs change, 36 lines added, no code touched.