### PR TITLE
exclude alpine linux from links checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -17,4 +17,5 @@ exclude = [
   'https://github.com/release-plz/release-plz/issues/*',
   # GitHub search returns 502 intermittently
   'https://github.com/search*',
+  'https://wiki.alpinelinux.org/*'
 ]


### PR DESCRIPTION
The links check failed on main 
<img width="2420" height="754" alt="image" src="https://github.com/user-attachments/assets/3f9b8200-af2d-4547-913e-96e9edc4e20c" />
