### PR TITLE
update to tera v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,7 +1674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "tera",
+ "tera 1.20.1",
  "thiserror 2.0.18",
  "time",
  "toml 0.9.12+spec-1.1.0",
@@ -4706,7 +4706,7 @@ dependencies = [
  "serde_json",
  "strip-ansi-escapes",
  "tempfile",
- "tera",
+ "tera 2.0.0",
  "test_logs",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -5598,6 +5598,15 @@ dependencies = [
  "serde_json",
  "slug",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "tera"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde = "1.0.219"
 serde_json = "1.0.143"
 strip-ansi-escapes = "0.2.1"
 tempfile = "3.22.0"
-tera = "1.20.0"
+tera = "2.0.0"
 tokio = "1.47.1"
 toml = { version = "1.0.0" }
 toml_edit = { version = "0.25.0" }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -7,7 +7,7 @@ use chrono::SecondsFormat;
 pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"
-{% macro get_changes(releases, type="text") %}
+{% set changes %}
 {%- for release in releases %}
 {%- if release.changelog %}{% if releases | length > 1 %}
 ## `{{ release.package }}`
@@ -19,9 +19,7 @@ pub const DEFAULT_PR_BODY_TEMPLATE: &str = r#"
 {{ release.changelog }}
 </blockquote>{% endif %}
 {% endfor %}
-{% endmacro -%}
-
-{% set changes = self::get_changes(releases=releases) %}
+{% endset %}
 
 ## 🤖 New release
 {% for release in releases %}
@@ -187,5 +185,31 @@ fn trim_pr_body(body: String) -> String {
         body.chars().take(MAX_BODY_LEN).collect()
     } else {
         body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_pr_body_template_renders() {
+        let releases = serde_json::json!([{
+            "package": "my-package",
+            "title": "[0.1.1] - 2026-06-27",
+            "changelog": "### Other\n\n- fixed a bug",
+            "previous_version": "0.1.0",
+            "next_version": "0.1.1",
+            "breaking_changes": null,
+            "semver_check": "compatible",
+        }]);
+        let mut context = tera::Context::new();
+        context.insert(RELEASES_VAR, &releases);
+
+        let body = render_template(DEFAULT_PR_BODY_TEMPLATE, &context, "pr_body").unwrap();
+
+        assert!(body.contains("## 🤖 New release"));
+        assert!(body.contains("* `my-package`: 0.1.0 -> 0.1.1 (✓ API compatible changes)"));
+        assert!(body.contains("- fixed a bug"));
     }
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -496,6 +496,7 @@ pr_body = """
 <blockquote>
 
 ## {{ release.title }}
+
 {{ release.changelog }}
 </blockquote>{% endif %}
 {% endfor %}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -490,13 +490,12 @@ The default PR body template is the following:
 pr_body = """
 {% set changes %}
 {%- for release in releases %}
-{%- if release.changelog %}{% if releases | length > 1 %}
+{%- if release.title and if release.changelog %}{% if releases | length > 1 %}
 ## `{{ release.package }}`
 {% endif %}
 <blockquote>
 
-{% if release.title %}## {{ release.title }}
-{% endif %}
+## {{ release.title }}
 {{ release.changelog }}
 </blockquote>{% endif %}
 {% endfor %}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -146,6 +146,12 @@ the following sections:
   - [`link_parsers`](#the-link_parsers-field) — Parse links in commit messages.
   - [`commit_parsers`](#the-commit_parsers-field) — Organize commits into sections.
 
+:::note
+The release-plz-rendered template fields `git_release_name`, `git_release_body`,
+`git_tag_name`, `pr_name`, and `pr_body` use Tera 2. Changelog templates configured
+through `changelog` or `changelog_config` are rendered by git-cliff, which still uses Tera 1.
+:::
+
 ### The `[workspace]` section
 
 Defines the global configuration, applied to all packages by default.

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -442,7 +442,7 @@ release-plz creates.
 
 By default it contains the summary of package updates, the changelog for each package, a section
 for breaking changes, and a footer with credits for release-plz. If the text is longer than
-65536 characters, the changelog isn't inclued.
+65536 characters, the changelog isn't included.
 This limit is imposed by Github.
 
 Here is an example of how you can customize the PR body template:
@@ -488,21 +488,19 @@ The default PR body template is the following:
 ````toml
 [workspace]
 pr_body = """
-{% macro get_changes(releases, type="text") %}
+{% set changes %}
 {%- for release in releases %}
-{%- if release.title and release.changelog %}{% if releases | length > 1 %}
+{%- if release.changelog %}{% if releases | length > 1 %}
 ## `{{ release.package }}`
 {% endif %}
 <blockquote>
 
-## {{ release.title }}
-
+{% if release.title %}## {{ release.title }}
+{% endif %}
 {{ release.changelog }}
 </blockquote>{% endif %}
 {% endfor %}
-{% endmacro -%}
-
-{% set changes = self::get_changes(releases=releases) %}
+{% endset %}
 
 ## 🤖 New release
 {% for release in releases %}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -490,7 +490,7 @@ The default PR body template is the following:
 pr_body = """
 {% set changes %}
 {%- for release in releases %}
-{%- if release.title and if release.changelog %}{% if releases | length > 1 %}
+{%- if release.title and release.changelog %}{% if releases | length > 1 %}
 ## `{{ release.package }}`
 {% endif %}
 <blockquote>


### PR DESCRIPTION
- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).
### Breaking change: custom templates now use Tera 2

release-plz now renders its configurable templates with Tera 2. The built-in templates have been migrated, so users who rely on the default templates do not need to change anything.

Macros are the most likely breakage. In particular, templates using `{% macro ... %}`, `{% endmacro %}`, or `self::some_macro(...)` will no longer render.
Other Tera 2 template changes may also apply.

Affected release-plz config fields:

- `pr_name`
- `pr_body`
- `git_tag_name`
- `git_release_name`
- `git_release_body`

For example, replace macro-based captured content like this:

```tera
{% macro get_changes(releases) %}
...
{% endmacro %}

{% set changes = self::get_changes(releases=releases) %}
```

with Tera 2 block assignment:

```tera
{% set changes %}
...
{% endset %}
```

Templates that only use variables, loops, conditionals, and supported filters should continue to work. Changelog templates rendered by git-cliff are not affected by this change.

I'm not doing a breaking change release because still the changelog template of git-cliff depends on tera 1 and I expect the most usage of macros is in the `changelog` field.

I'll probably do a breaking change release when git-cliff migrates to tera 2.

To migrate, see https://github.com/Keats/tera/blob/master/MIGRATION.md

## AI Disclosure

gpt 5.5 made this change and most of the breaking change notes.
