### PR TITLE
feat: add `signoff` config option for release commits

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -67,7 +67,8 @@
         "release_always": null,
         "release_commits": null,
         "repo_url": null,
-        "semver_check": null
+        "semver_check": null,
+        "signoff": false
       }
     }
   },
@@ -804,6 +805,12 @@
             "boolean",
             "null"
           ]
+        },
+        "signoff": {
+          "title": "Sign-off",
+          "description": "If `true`, add a `Signed-off-by` trailer to the release commit\n(like `git commit --signoff`), e.g. to comply with a Developer Certificate of Origin (DCO).\nThe trailer uses the `user.name` and `user.email` of the git configuration.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -151,6 +151,18 @@ impl Repo {
         Ok(())
     }
 
+    /// The `Signed-off-by` trailer that `git commit --signoff` would add, built from
+    /// the `user.name` and `user.email` of the git configuration.
+    pub fn signoff_trailer(&self) -> anyhow::Result<String> {
+        let name = self
+            .git(&["config", "user.name"])
+            .context("failed to get `user.name` from git config, needed for the sign-off trailer")?;
+        let email = self.git(&["config", "user.email"]).context(
+            "failed to get `user.email` from git config, needed for the sign-off trailer",
+        )?;
+        Ok(format!("Signed-off-by: {name} <{email}>"))
+    }
+
     pub fn push(&self, obj: &str) -> anyhow::Result<()> {
         self.git(&["push", &self.original_remote, obj])?;
         Ok(())

--- a/crates/release_plz/src/args/release_pr.rs
+++ b/crates/release_plz/src/args/release_pr.rs
@@ -25,13 +25,15 @@ impl ReleasePr {
         let pr_body = config.workspace.pr_body.clone();
         let pr_labels = config.workspace.pr_labels.clone();
         let pr_draft = config.workspace.pr_draft;
+        let signoff = config.workspace.signoff;
         let update_request = self.update.update_request(config, cargo_metadata)?;
         let request = ReleasePrRequest::new(update_request)
             .mark_as_draft(pr_draft)
             .with_labels(pr_labels)
             .with_branch_prefix(pr_branch_prefix)
             .with_pr_name_template(pr_name)
-            .with_pr_body_template(pr_body);
+            .with_pr_body_template(pr_body)
+            .with_signoff(signoff);
         Ok(request)
     }
 }

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -189,6 +189,12 @@ pub struct Workspace {
     /// # PR Branch Prefix
     /// Prefix for the PR Branch
     pub pr_branch_prefix: Option<String>,
+    /// # Sign-off
+    /// If `true`, add a `Signed-off-by` trailer to the release commit
+    /// (like `git commit --signoff`), e.g. to comply with a Developer Certificate of Origin (DCO).
+    /// The trailer uses the `user.name` and `user.email` of the git configuration.
+    #[serde(default)]
+    pub signoff: bool,
     /// # Publish Timeout
     /// Timeout for the publishing process
     pub publish_timeout: Option<String>,
@@ -230,6 +236,7 @@ impl Default for Workspace {
             pr_draft: false,
             pr_labels: Vec::new(),
             pr_branch_prefix: None,
+            signoff: false,
             publish_timeout: None,
             release_commits: None,
             release_always: None,
@@ -611,6 +618,7 @@ mod tests {
                 pr_draft: false,
                 pr_labels: vec![],
                 pr_branch_prefix: Some("f-".to_string()),
+                signoff: false,
                 publish_timeout: Some("10m".to_string()),
                 release_commits: Some("^feat:".to_string()),
                 release_always: None,
@@ -726,6 +734,7 @@ mod tests {
                 pr_draft: false,
                 pr_labels: vec!["label1".to_string()],
                 pr_branch_prefix: Some("f-".to_string()),
+                signoff: false,
                 packages_defaults: PackageConfig {
                     semver_check: None,
                     changelog_update: true.into(),
@@ -772,6 +781,7 @@ mod tests {
             pr_draft = false
             pr_labels = ["label1"]
             pr_branch_prefix = "f-"
+            signoff = false
             publish_timeout = "10m"
             repo_url = "https://github.com/release-plz/release-plz"
             release_commits = "^feat:"

--- a/crates/release_plz_core/src/command/release_pr/mod.rs
+++ b/crates/release_plz_core/src/command/release_pr/mod.rs
@@ -33,6 +33,8 @@ pub struct ReleasePrRequest {
     labels: Vec<String>,
     /// PR Branch Prefix
     branch_prefix: String,
+    /// If `true`, add a `Signed-off-by` trailer to the release commit.
+    signoff: bool,
     pub update_request: UpdateRequest,
 }
 
@@ -44,6 +46,7 @@ impl ReleasePrRequest {
             draft: false,
             labels: vec![],
             branch_prefix: DEFAULT_BRANCH_PREFIX.to_string(),
+            signoff: false,
             update_request,
         }
     }
@@ -72,6 +75,11 @@ impl ReleasePrRequest {
         if let Some(branch_prefix) = pr_branch_prefix {
             self.branch_prefix = branch_prefix;
         }
+        self
+    }
+
+    pub fn with_signoff(mut self, signoff: bool) -> Self {
+        self.signoff = signoff;
         self
     }
 }
@@ -165,6 +173,7 @@ pub async fn release_pr(input: &ReleasePrRequest) -> anyhow::Result<Option<Relea
                     pr_body: input.pr_body_template.clone(),
                     pr_labels: input.labels.clone(),
                     pr_branch_prefix: input.branch_prefix.clone(),
+                    signoff: input.signoff,
                 },
             )
             .await?;
@@ -181,6 +190,7 @@ struct ReleasePrOptions {
     pr_body: Option<String>,
     pr_labels: Vec<String>,
     pr_branch_prefix: String,
+    signoff: bool,
 }
 
 async fn open_or_update_release_pr(
@@ -227,6 +237,7 @@ async fn open_or_update_release_pr(
         )?
         .mark_as_draft(release_pr_options.draft)
         .with_labels(release_pr_options.pr_labels)
+        .with_signoff(release_pr_options.signoff)
     };
     let release_pr = match opened_release_prs.first() {
         Some(opened_pr) => {
@@ -311,9 +322,9 @@ async fn handle_opened_pr(
 async fn create_pr(git_client: &GitClient, repo: &Repo, pr: &Pr) -> anyhow::Result<ReleasePr> {
     repo.checkout_new_branch(&pr.branch)?;
     if git_client.forge == ForgeType::Github {
-        github_create_release_branch(git_client, repo, &pr.branch, &pr.title).await?;
+        github_create_release_branch(git_client, repo, &pr.branch, &pr.title, pr.signoff).await?;
     } else {
-        create_release_branch(repo, &pr.branch, &pr.title)?;
+        create_release_branch(repo, &pr.branch, &pr.title, pr.signoff)?;
     }
     debug!("changes committed to release branch {}", pr.branch);
 
@@ -336,9 +347,9 @@ async fn update_pr(
         )
     })?;
     if git_client.forge == ForgeType::Github {
-        github_force_push(git_client, opened_pr, repository).await?;
+        github_force_push(git_client, opened_pr, repository, new_pr.signoff).await?;
     } else {
-        force_push(opened_pr, repository)?;
+        force_push(opened_pr, repository, new_pr.signoff)?;
     }
     let pr_edit = {
         let mut pr_edit = PrEdit::new();
@@ -417,8 +428,8 @@ fn reset_branch(
     Ok(())
 }
 
-fn force_push(pr: &GitPr, repository: &Repo) -> anyhow::Result<()> {
-    add_changes_and_commit(repository, &pr.title)?;
+fn force_push(pr: &GitPr, repository: &Repo, signoff: bool) -> anyhow::Result<()> {
+    add_changes_and_commit(repository, &pr.title, signoff)?;
     repository.force_push(pr.branch())?;
     Ok(())
 }
@@ -427,6 +438,7 @@ async fn github_force_push(
     client: &GitClient,
     pr: &GitPr,
     repository: &Repo,
+    signoff: bool,
 ) -> anyhow::Result<()> {
     let tmp_release_branch = format!("{}-tmp-{}", pr.branch(), rand::random::<u32>());
     repository.checkout_new_branch(&tmp_release_branch)?;
@@ -440,7 +452,8 @@ async fn github_force_push(
     //   because the branch is the same as the default branch. So we can't revert the latest release-plz commit and push the new one.
     // To learn more, see https://github.com/release-plz/release-plz/issues/1487
     let sha =
-        github_create_release_branch(client, repository, &tmp_release_branch, &pr.title).await?;
+        github_create_release_branch(client, repository, &tmp_release_branch, &pr.title, signoff)
+            .await?;
 
     let force_push_result =
         execute_github_force_push(client, pr, repository, &tmp_release_branch, &sha).await;
@@ -474,8 +487,9 @@ fn create_release_branch(
     repository: &Repo,
     release_branch: &str,
     commit_message: &str,
+    signoff: bool,
 ) -> anyhow::Result<()> {
-    add_changes_and_commit(repository, commit_message)?;
+    add_changes_and_commit(repository, commit_message, signoff)?;
     repository.push(release_branch)?;
     Ok(())
 }
@@ -485,10 +499,12 @@ async fn github_create_release_branch(
     repository: &Repo,
     release_branch: &str,
     commit_message: &str,
+    signoff: bool,
 ) -> anyhow::Result<String> {
     let sha = repository.current_commit_hash()?;
     client.create_branch(release_branch, &sha).await?;
-    let sha = github_graphql::commit_changes(client, repository, commit_message, release_branch)
+    let commit_message = commit_message_with_signoff(repository, commit_message, signoff)?;
+    let sha = github_graphql::commit_changes(client, repository, &commit_message, release_branch)
         .await
         .with_context(|| {
             format!("failed to create commit via graphql on branch `{release_branch}`")
@@ -497,9 +513,34 @@ async fn github_create_release_branch(
     Ok(sha)
 }
 
-fn add_changes_and_commit(repository: &Repo, commit_message: &str) -> anyhow::Result<()> {
+fn add_changes_and_commit(
+    repository: &Repo,
+    commit_message: &str,
+    signoff: bool,
+) -> anyhow::Result<()> {
     let changes_expect_typechanges = repository.changes_except_typechanges()?;
     repository.add(&changes_expect_typechanges)?;
-    repository.commit_signed(commit_message)?;
+    if signoff {
+        repository.commit_signed(commit_message)?;
+    } else {
+        repository.commit(commit_message)?;
+    }
     Ok(())
+}
+
+/// Append the `Signed-off-by` trailer to the commit message if `signoff` is enabled.
+///
+/// The git-based commit paths use `git commit --signoff` directly, but the GitHub GraphQL
+/// commit doesn't go through `git`, so we add the trailer to the message ourselves.
+fn commit_message_with_signoff(
+    repository: &Repo,
+    commit_message: &str,
+    signoff: bool,
+) -> anyhow::Result<String> {
+    if signoff {
+        let trailer = repository.signoff_trailer()?;
+        Ok(format!("{commit_message}\n\n{trailer}"))
+    } else {
+        Ok(commit_message.to_string())
+    }
 }

--- a/crates/release_plz_core/src/git/github_graphql.rs
+++ b/crates/release_plz_core/src/git/github_graphql.rs
@@ -114,12 +114,24 @@ impl GithubCommit {
             .await
             .context("failed to get git additions")?;
 
+        // Split the commit message into the headline (first line) and the body (the rest),
+        // so that trailers like `Signed-off-by` end up in the commit body.
+        let (headline, body) = match message.split_once('\n') {
+            Some((headline, body)) => (headline, body.trim_start_matches('\n')),
+            None => (message.as_str(), ""),
+        };
+        let commit_message = if body.is_empty() {
+            json!({"headline": headline})
+        } else {
+            json!({"headline": headline, "body": body})
+        };
+
         let input = json!({
             "branch": {
                 "repositoryNameWithOwner": owner_slash_repo,
                 "branchName": branch,
             },
-            "message": {"headline": message},
+            "message": commit_message,
             "expectedHeadOid": current_head,
             "fileChanges": {
                 "deletions": deletions,
@@ -258,5 +270,27 @@ mod tests {
 
         expect_test::expect![[r#""mutation($input:CreateCommitOnBranchInput!){createCommitOnBranch(input:$input){commit{oid}}}""#]]
         .assert_eq(&query["query"].to_string());
+    }
+
+    #[tokio::test]
+    async fn commit_message_with_trailer_is_split_into_headline_and_body() {
+        let temporary = tempdir().unwrap();
+        let repo_dir = temporary.as_ref();
+        let repo = Repo::init(repo_dir);
+
+        let message = "chore: release v1.2.3\n\nSigned-off-by: Test User <test@example.com>";
+        let query = GithubCommit::new("owner/repo", &repo, message, "main")
+            .unwrap()
+            .to_query_json()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            query["variables"]["input"]["message"],
+            json!({
+                "headline": "chore: release v1.2.3",
+                "body": "Signed-off-by: Test User <test@example.com>",
+            })
+        );
     }
 }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -48,6 +48,8 @@ pub struct Pr {
     pub body: String,
     pub draft: bool,
     pub labels: Vec<String>,
+    /// If `true`, add a `Signed-off-by` trailer to the release commit.
+    pub signoff: bool,
 }
 
 impl Pr {
@@ -70,12 +72,18 @@ impl Pr {
             body: pr_body(packages_to_update, body_template)?,
             draft: false,
             labels: vec![],
+            signoff: false,
         };
         Ok(pr)
     }
 
     pub fn mark_as_draft(mut self, draft: bool) -> Self {
         self.draft = draft;
+        self
+    }
+
+    pub fn with_signoff(mut self, signoff: bool) -> Self {
+        self.signoff = signoff;
         self
     }
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -104,6 +104,7 @@ the following sections:
     packages.
   - [`repo_url`](#the-repo_url-field) — Repository URL.
   - [`semver_check`](#the-semver_check-field) — Run [cargo-semver-checks].
+  - [`signoff`](#the-signoff-field) — Add a `Signed-off-by` trailer to the release commit.
 - [`[[package]]`](#the-package-section) — Package-specific configurations.
   - [`name`](#the-name-field) — Package name. *(Required)*.
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
@@ -743,6 +744,29 @@ API breaking changes of your package:
 :::
 
 This field can be overridden in the [`[package]`](#the-package-section) section.
+
+#### The `signoff` field
+
+- If `true`, release-plz adds a `Signed-off-by` trailer to the release commit,
+  like `git commit --signoff` does. This is useful to comply with a
+  [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+- If `false`, no trailer is added. *(Default)*.
+
+The trailer uses the `user.name` and `user.email` of the git configuration, so make
+sure they are set (e.g. in CI):
+
+```toml
+[workspace]
+signoff = true
+```
+
+The resulting commit message looks like:
+
+```text
+chore: release v1.2.3
+
+Signed-off-by: Your Name <you@example.com>
+```
 
 ### The `[[package]]` section
 


### PR DESCRIPTION
## Summary

Adds a `signoff` boolean config option that appends a `Signed-off-by` trailer to the release commit, like `git commit --signoff`. This makes release-plz usable in repositories that enforce a [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

```toml
[workspace]
signoff = true
```

Resulting commit:

```text
chore: release v1.2.3

Signed-off-by: Your Name <you@example.com>
```

Defaults to `false`.

## Motivation

Today release-plz creates the release commit either via `git` (GitLab/Gitea) or via the GitHub GraphQL `createCommitOnBranch` mutation (GitHub, for the "Verified" badge). The GraphQL path only set `headline` and never added a sign-off, so DCO checks fail on GitHub. There was also no way to control sign-off behavior.

## Changes

- New `signoff` workspace config option (`crates/release_plz/src/config.rs`), plumbed through `ReleasePrRequest` → `Pr`.
- The trailer is derived from git `user.name`/`user.email` via a new `Repo::signoff_trailer()` helper.
- **git-based paths** (GitLab/Gitea): use `git commit --signoff` when enabled, plain `git commit` otherwise.
- **GitHub GraphQL path**: append the trailer to the commit message and split the message into `headline`/`body` so the trailer lands in the commit body.
- Schema (`.schema/latest.json`) regenerated and docs (`website/docs/config.md`) updated.
- Added a unit test for the headline/body split.

## Notes / decision needed

Previously the git-based path **always** passed `-s` (the `commit_signed` helper), while the GitHub path never did. This PR makes both paths consistent and gated behind the new option, which **defaults to `false`** — so non-GitHub users who relied on the implicit sign-off will need to set `signoff = true`. Happy to change the default to `true` instead if preserving the old GitLab/Gitea behavior is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)