### PR TITLE
fix: Parse 'footer' in commit parsers

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -190,6 +190,13 @@
             "null"
           ]
         },
+        "footer": {
+          "description": "Regex for matching the commit footer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "group": {
           "description": "Group of the commit.",
           "type": [

--- a/crates/release_plz/src/changelog_config.rs
+++ b/crates/release_plz/src/changelog_config.rs
@@ -106,6 +106,8 @@ pub struct CommitParser {
     pub message: Option<String>,
     /// Regex for matching the commit body.
     pub body: Option<String>,
+    /// Regex for matching the commit footer.
+    pub footer: Option<String>,
     /// Group of the commit.
     pub group: Option<String>,
     /// Default scope of the commit.
@@ -136,7 +138,7 @@ impl TryFrom<CommitParser> for git_cliff_core::config::CommitParser {
             field: cfg.field,
             pattern: to_opt_regex(cfg.pattern.as_deref(), "pattern")?,
             sha: cfg.sha,
-            footer: None,
+            footer: to_opt_regex(cfg.footer.as_deref(), "footer")?,
         })
     }
 }
@@ -248,7 +250,7 @@ mod tests {
             ]
 
             commit_parsers = [
-                { message = "message", body = "body", group = "group", default_scope = "default_scope", scope = "scope", skip = true, field = "field", pattern = "pattern"}
+                { message = "message", body = "body", footer = "footer", group = "group", default_scope = "default_scope", scope = "scope", skip = true, field = "field", pattern = "pattern"}
             ]
 
             link_parsers = [
@@ -295,7 +297,7 @@ mod tests {
                     field: Some("field".to_string()),
                     pattern: Some(regex::Regex::new("pattern").unwrap()),
                     sha: None,
-                    footer: None,
+                    footer: Some(regex::Regex::new("footer").unwrap()),
                 }],
                 link_parsers: vec![git_cliff_core::config::LinkParser {
                     pattern: regex::Regex::new("pattern").unwrap(),


### PR DESCRIPTION
The `footer` field in the toml commit_parsers was not parsed or forwarded to git-cliff. An example from the documentation which uses `footer` doesn't work in the actual code:
https://github.com/release-plz/release-plz/blob/795d07f211dc6eea0517fb1de85b61ab309741d6/website/docs/config.md?plain=1#L1165

- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

This bug was found when I was diagnosing my use of release-plz in my own repo, I had tried to add a `footer` commit parser and it was not working. I used Claude Opus 4.8 with Claude Code to help me diagnose the issue and figure out where to put the fix. I self-reviewed the resulting fix.