### PR TITLE
fix: update packages in `version_group` when using `release_commits` setting

### DIFF
--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1656,9 +1656,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     );
 }
 
-#[tokio::test]
-#[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn release_plz_updates_whole_version_group_with_matching_release_commits() {
+async fn version_group_with_bar_change(commit_message: &str) -> TestContext {
     let foo = "foo";
     let bar = "bar";
 
@@ -1691,7 +1689,15 @@ version_group = "a"
 
     let bar_file = context.package_path(bar).join("src").join("aa.rs");
     fs_err::write(&bar_file, "pub fn bar() {}").unwrap();
-    context.push_all_changes("feat: update bar");
+    context.push_all_changes(commit_message);
+
+    context
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_updates_whole_version_group_with_matching_release_commits() {
+    let context = version_group_with_bar_change("feat: update bar").await;
 
     context.run_release_pr().success();
     let opened_prs = context.opened_release_prs().await;
@@ -1699,50 +1705,19 @@ version_group = "a"
 
     let pr_body = opened_prs[0].body.as_ref().unwrap();
     assert!(
-        pr_body.contains(&format!("`{foo}`: 0.1.0 -> 0.1.1")),
-        "expected `{foo}` to be bumped alongside its version group"
+        pr_body.contains("`foo`: 0.1.0 -> 0.1.1"),
+        "expected `foo` to be bumped alongside its version group"
     );
     assert!(
-        pr_body.contains(&format!("`{bar}`: 0.1.0 -> 0.1.1")),
-        "expected `{bar}` to be bumped"
+        pr_body.contains("`bar`: 0.1.0 -> 0.1.1"),
+        "expected `bar` to be bumped"
     );
 }
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_does_not_release_version_group_without_matching_release_commits() {
-    let foo = "foo";
-    let bar = "bar";
-    let context = TestContext::new_workspace_with_packages(&[
-        TestPackage::new(bar)
-            .with_type(PackageType::Lib)
-            .with_path_dependencies(vec![format!("../{foo}")]),
-        TestPackage::new(foo).with_type(PackageType::Lib),
-    ])
-    .await;
-    context.run_release_pr().success();
-    context.merge_release_pr().await;
-    context.run_release().success();
-
-    let config = format!(
-        r#"
-[workspace]
-release_commits = "^feat"
-
-[[package]]
-name = "{foo}"
-version_group = "a"
-
-[[package]]
-name = "{bar}"
-version_group = "a"
-"#
-    );
-    context.write_release_plz_toml(&config);
-
-    let bar_file = context.package_path(bar).join("src").join("aa.rs");
-    fs_err::write(&bar_file, "pub fn bar() {}").unwrap();
-    context.push_all_changes("chore: update bar");
+    let context = version_group_with_bar_change("chore: update bar").await;
 
     context.run_release_pr().success();
     let opened_prs = context.opened_release_prs().await;

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1655,3 +1655,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         )
     );
 }
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_updates_whole_version_group_with_matching_release_commits() {
+    let foo = "foo";
+    let bar = "bar";
+
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new(bar)
+            .with_type(PackageType::Lib)
+            .with_path_dependencies(vec![format!("../{foo}")]),
+        TestPackage::new(foo).with_type(PackageType::Lib),
+    ])
+    .await;
+    context.run_release_pr().success();
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    let config = format!(
+        r#"
+[workspace]
+release_commits = "^feat"
+
+[[package]]
+name = "{foo}"
+version_group = "a"
+
+[[package]]
+name = "{bar}"
+version_group = "a"
+"#
+    );
+    context.write_release_plz_toml(&config);
+
+    let bar_file = context.package_path(bar).join("src").join("aa.rs");
+    fs_err::write(&bar_file, "pub fn bar() {}").unwrap();
+    context.push_all_changes("feat: update bar");
+
+    context.run_release_pr().success();
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(opened_prs.len(), 1);
+
+    let pr_body = opened_prs[0].body.as_ref().unwrap();
+    assert!(
+        pr_body.contains(&format!("`{foo}`: 0.1.0 -> 0.1.1")),
+        "expected `{foo}` to be bumped alongside its version group"
+    );
+    assert!(
+        pr_body.contains(&format!("`{bar}`: 0.1.0 -> 0.1.1")),
+        "expected `{bar}` to be bumped"
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_does_not_release_version_group_without_matching_release_commits() {
+    let foo = "foo";
+    let bar = "bar";
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new(bar)
+            .with_type(PackageType::Lib)
+            .with_path_dependencies(vec![format!("../{foo}")]),
+        TestPackage::new(foo).with_type(PackageType::Lib),
+    ])
+    .await;
+    context.run_release_pr().success();
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    let config = format!(
+        r#"
+[workspace]
+release_commits = "^feat"
+
+[[package]]
+name = "{foo}"
+version_group = "a"
+
+[[package]]
+name = "{bar}"
+version_group = "a"
+"#
+    );
+    context.write_release_plz_toml(&config);
+
+    let bar_file = context.package_path(bar).join("src").join("aa.rs");
+    fs_err::write(&bar_file, "pub fn bar() {}").unwrap();
+    context.push_all_changes("chore: update bar");
+
+    context.run_release_pr().success();
+    let opened_prs = context.opened_release_prs().await;
+    assert!(
+        opened_prs.is_empty(),
+        "expected no release PR since no commit matches `release_commits`"
+    );
+}

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -1702,15 +1702,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     );
 }
 
-async fn version_group_with_bar_change(commit_message: &str) -> TestContext {
-    let foo = "foo";
-    let bar = "bar";
+async fn version_group_with_dependent_change(commit_message: &str) -> TestContext {
+    let dependency = "dependency";
+    let dependent = "dependent";
 
     let context = TestContext::new_workspace_with_packages(&[
-        TestPackage::new(bar)
+        TestPackage::new(dependent)
             .with_type(PackageType::Lib)
-            .with_path_dependencies(vec![format!("../{foo}")]),
-        TestPackage::new(foo).with_type(PackageType::Lib),
+            .with_path_dependencies(vec![format!("../{dependency}")]),
+        TestPackage::new(dependency).with_type(PackageType::Lib),
     ])
     .await;
     context.run_release_pr().success();
@@ -1723,18 +1723,18 @@ async fn version_group_with_bar_change(commit_message: &str) -> TestContext {
 release_commits = "^feat"
 
 [[package]]
-name = "{foo}"
+name = "{dependency}"
 version_group = "a"
 
 [[package]]
-name = "{bar}"
+name = "{dependent}"
 version_group = "a"
 "#
     );
     context.write_release_plz_toml(&config);
 
-    let bar_file = context.package_path(bar).join("src").join("aa.rs");
-    fs_err::write(&bar_file, "pub fn bar() {}").unwrap();
+    let dependent_file = context.package_path(dependent).join("src").join("aa.rs");
+    fs_err::write(&dependent_file, "pub fn dependent() {}").unwrap();
     context.push_all_changes(commit_message);
 
     context
@@ -1743,7 +1743,7 @@ version_group = "a"
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_updates_whole_version_group_with_matching_release_commits() {
-    let context = version_group_with_bar_change("feat: update bar").await;
+    let context = version_group_with_dependent_change("feat: update dependent").await;
 
     context.run_release_pr().success();
     let opened_prs = context.opened_release_prs().await;
@@ -1751,19 +1751,19 @@ async fn release_plz_updates_whole_version_group_with_matching_release_commits()
 
     let pr_body = opened_prs[0].body.as_ref().unwrap();
     assert!(
-        pr_body.contains("`foo`: 0.1.0 -> 0.1.1"),
-        "expected `foo` to be bumped alongside its version group"
+        pr_body.contains("`dependency`: 0.1.0 -> 0.1.1"),
+        "expected `dependency` to be bumped alongside its version group"
     );
     assert!(
-        pr_body.contains("`bar`: 0.1.0 -> 0.1.1"),
-        "expected `bar` to be bumped"
+        pr_body.contains("`dependent`: 0.1.0 -> 0.1.1"),
+        "expected `dependent` to be bumped"
     );
 }
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_does_not_release_version_group_without_matching_release_commits() {
-    let context = version_group_with_bar_change("chore: update bar").await;
+    let context = version_group_with_dependent_change("chore: update dependent").await;
 
     context.run_release_pr().success();
     let opened_prs = context.opened_release_prs().await;

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -90,14 +90,16 @@ impl Updater<'_> {
 
         let mut old_changelogs = OldChangelogs::new();
         for (p, diff) in packages_diffs {
-            let pkg_config = self.req.get_package_config(&p.name);
-            let group_has_release_commit = pkg_config
-                .version_group
-                .as_ref()
-                .is_some_and(|group| version_groups_with_release_commit.contains(group));
+            let group_has_release_commit = || {
+                self.req
+                    .get_package_config(&p.name)
+                    .version_group
+                    .as_ref()
+                    .is_some_and(|group| version_groups_with_release_commit.contains(group))
+            };
             if let Some(release_commits_regex) = self.req.release_commits()
                 && !diff.any_commit_matches(release_commits_regex)
-                && !group_has_release_commit
+                && !group_has_release_commit()
             {
                 info!("{}: no commit matches the `release_commits` regex", p.name);
                 // We need to update this package only if one of its dependencies has changed.

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -63,6 +63,8 @@ impl Updater<'_> {
             .await?;
         let version_groups = self.get_version_groups(&packages_diffs)?;
         debug!("version groups: {:?}", version_groups);
+        let version_groups_with_release_commit =
+            self.version_groups_with_release_commit(&packages_diffs);
 
         let mut packages_to_check_for_deps: Vec<&Package> = vec![];
         let mut packages_to_update = PackagesUpdate::default();
@@ -88,8 +90,14 @@ impl Updater<'_> {
 
         let mut old_changelogs = OldChangelogs::new();
         for (p, diff) in packages_diffs {
+            let pkg_config = self.req.get_package_config(&p.name);
+            let group_has_release_commit = pkg_config
+                .version_group
+                .as_ref()
+                .is_some_and(|group| version_groups_with_release_commit.contains(group));
             if let Some(release_commits_regex) = self.req.release_commits()
                 && !diff.any_commit_matches(release_commits_regex)
+                && !group_has_release_commit
             {
                 info!("{}: no commit matches the `release_commits` regex", p.name);
                 // We need to update this package only if one of its dependencies has changed.
@@ -186,6 +194,24 @@ impl Updater<'_> {
         }
 
         Ok(version_groups)
+    }
+
+    fn version_groups_with_release_commit(
+        &self,
+        packages_diffs: &[(&Package, Diff)],
+    ) -> HashSet<String> {
+        let mut groups = HashSet::new();
+        if let Some(release_commits_regex) = self.req.release_commits() {
+            for (pkg, diff) in packages_diffs {
+                let pkg_config = self.req.get_package_config(&pkg.name);
+                if let Some(version_group) = pkg_config.version_group
+                    && diff.any_commit_matches(release_commits_regex)
+                {
+                    groups.insert(version_group);
+                }
+            }
+        }
+        groups
     }
 
     fn new_workspace_version(

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -697,6 +697,9 @@ In `release-plz update` and `release-plz release-pr`, `release-plz` bumps the ve
 the changelog of the package only if at least one of the commits matches the `release_commits`
 regex.
 
+For packages in a [`version_group`](#the-version_group-field), a matching commit in any member
+allows all packages in the group to update, even if their own commits do not match.
+
 You can use this if you think it is too noisy to raise PRs on every commit.
 
 Examples:


### PR DESCRIPTION
Fixes a bug where, when specifying both `version_group` and `release_commits` settings, updating A (which depends on B), also updates B.

- Closes #2891

----

- [X] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

Claude helped write tests based on the reproduction I created in #2891. I've also tested it manually on my repro repo here: https://github.com/ok-nick/release-plz-bug-repro/tree/main