### PR TITLE
fix(core): collect all commits after the last release for the changelog

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -218,6 +218,52 @@ impl Repo {
         Ok(())
     }
 
+    /// Hashes of the commits that modified `paths`, from newest (`HEAD`) to oldest,
+    /// excluding any commit reachable from one of `boundary_commits` (typically the git tag
+    /// and/or the commit at which the last version was published).
+    ///
+    /// Bounding the walk by the last release — rather than walking commit by commit and
+    /// stopping at the first already-released commit — matters in the presence of merge
+    /// commits: a commit-by-commit walk can descend into a branch that forked *before* the
+    /// last release and rejoin already-released history, stopping early and dropping the
+    /// commits that landed on the main line after the release (release-plz#2494).
+    ///
+    /// `head` must be the branch tip the changelog is being computed for (not necessarily the
+    /// currently checked-out commit). Only boundary commits that are ancestors of `head` are
+    /// used: a commit that isn't reachable from `head` (a newer release living on another
+    /// branch, a hash missing from a shallow clone, or simply the tag of a package unchanged
+    /// since before `head`) isn't a point `head` was released at, and excluding it would
+    /// wrongly drop the commits it shares with `head`. At most `max_commits` are returned.
+    pub fn commits_at_paths_since(
+        &self,
+        head: &str,
+        boundary_commits: &[&str],
+        paths: &[&Path],
+        max_commits: u32,
+    ) -> anyhow::Result<Vec<String>> {
+        let excludes: Vec<String> = boundary_commits
+            .iter()
+            .filter(|commit| self.is_ancestor(commit, head))
+            .map(|commit| format!("^{commit}"))
+            .collect();
+        // `u32::MAX` means "no limit"; git's `--max-count` doesn't accept a value that large.
+        let max_commits = (max_commits != u32::MAX).then(|| max_commits.to_string());
+
+        let mut git_args = vec!["log", "--format=%H"];
+        if let Some(max_commits) = &max_commits {
+            git_args.push("--max-count");
+            git_args.push(max_commits.as_str());
+        }
+        git_args.push(head);
+        git_args.extend(excludes.iter().map(String::as_str));
+        git_args.push("--");
+        for p in paths {
+            git_args.push(p.to_str().expect("invalid path"));
+        }
+        let commit_list = self.git(&git_args)?;
+        Ok(commit_list.lines().map(|c| c.to_string()).collect())
+    }
+
     #[instrument(skip(self))]
     pub fn checkout(&self, object: &str) -> anyhow::Result<()> {
         self.git(&["checkout", object])
@@ -478,6 +524,145 @@ mod tests {
         }
         repo.checkout_previous_commit_at_paths(&[&file2]).unwrap();
         assert_eq!(repo.current_commit_message().unwrap(), "file2-1");
+    }
+
+    /// A feature branch that forks *before* a release and merges *after* it must not hide
+    /// the commits that landed on the main line between the release and the merge.
+    /// Regression test for release-plz#2494.
+    #[test]
+    fn commits_at_paths_since_keeps_main_line_after_a_straddling_merge() {
+        test_logs::init();
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let pkg = repository_dir.as_ref().join("pkg");
+        fs_err::create_dir_all(&pkg).unwrap();
+        let lib = pkg.join("lib.rs");
+
+        // Base commit. The feature branch forks from here, i.e. before the release.
+        fs_err::write(&lib, b"0").unwrap();
+        repo.add_all_and_commit("base").unwrap();
+        let base = repo.current_commit_hash().unwrap();
+
+        // Release commit on the main line, tagged: this is the last released version.
+        fs_err::write(&lib, b"1").unwrap();
+        repo.add_all_and_commit("release").unwrap();
+        repo.git(&["tag", "v1"]).unwrap();
+        let release = repo.current_commit_hash().unwrap();
+
+        // Two commits that land on the main line after the release. These are the commits
+        // the old commit-by-commit walk dropped.
+        fs_err::write(&lib, b"2").unwrap();
+        repo.add_all_and_commit("main-after-release-1").unwrap();
+        let main_1 = repo.current_commit_hash().unwrap();
+        fs_err::write(pkg.join("extra.rs"), b"x").unwrap();
+        repo.add_all_and_commit("main-after-release-2").unwrap();
+        let main_2 = repo.current_commit_hash().unwrap();
+
+        // A feature branch forked from `base` (before the release) and merged after it.
+        repo.git(&["checkout", "-b", "feature", &base]).unwrap();
+        fs_err::write(pkg.join("feature.rs"), b"f").unwrap();
+        repo.add_all_and_commit("feature").unwrap();
+        let feature = repo.current_commit_hash().unwrap();
+        repo.checkout(&main_2).unwrap();
+        repo.git(&["merge", "--no-ff", "feature", "-m", "merge feature"])
+            .unwrap();
+
+        let commits = repo
+            .commits_at_paths_since("HEAD", &[&release], &[pkg.as_ref()], u32::MAX)
+            .unwrap();
+
+        // All three commits made after the release are collected, regardless of the branch
+        // they landed on.
+        for expected in [&main_1, &main_2, &feature] {
+            assert!(
+                commits.contains(expected),
+                "expected commit {expected} to be collected, got {commits:?}"
+            );
+        }
+        // Already-released commits are excluded.
+        for released in [&base, &release] {
+            assert!(
+                !commits.contains(released),
+                "released commit {released} should not be collected, got {commits:?}"
+            );
+        }
+    }
+
+    /// A boundary that is not an ancestor of `HEAD` (a newer release published on another
+    /// branch, or a hash missing from a shallow clone) is ignored, so the commits it shares
+    /// with `HEAD` are not dropped.
+    #[test]
+    fn commits_at_paths_since_ignores_non_ancestor_boundaries() {
+        test_logs::init();
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let file = repository_dir.as_ref().join("file.rs");
+
+        fs_err::write(&file, b"0").unwrap();
+        repo.add_all_and_commit("first").unwrap();
+        let first = repo.current_commit_hash().unwrap();
+
+        // A commit on a divergent branch: it shares `first` with the main line but is not an
+        // ancestor of it. Excluding it would wrongly drop `first`.
+        repo.git(&["checkout", "-b", "other"]).unwrap();
+        fs_err::write(repository_dir.as_ref().join("other.rs"), b"x").unwrap();
+        repo.add_all_and_commit("other").unwrap();
+        let other = repo.current_commit_hash().unwrap();
+
+        // Back on the main line, advancing HEAD past the fork point.
+        repo.checkout(&first).unwrap();
+        fs_err::write(&file, b"1").unwrap();
+        repo.add_all_and_commit("second").unwrap();
+        let second = repo.current_commit_hash().unwrap();
+
+        let bogus = "0000000000000000000000000000000000000000";
+        for boundary in [other.as_str(), bogus] {
+            let commits = repo
+                .commits_at_paths_since("HEAD", &[boundary], &[file.as_ref()], u32::MAX)
+                .unwrap();
+            assert!(
+                commits.contains(&first) && commits.contains(&second),
+                "boundary {boundary} should have been ignored, got {commits:?}"
+            );
+        }
+    }
+
+    /// The walk is bounded by the `head` argument, not by whatever commit is currently checked
+    /// out. A package untouched since before the release must not dump its entire history just
+    /// because the caller moved `HEAD` to an old commit (the release boundary is still an
+    /// ancestor of `head`, so it applies).
+    #[test]
+    fn commits_at_paths_since_bounds_by_head_arg_not_checked_out_commit() {
+        test_logs::init();
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let stable = repository_dir.as_ref().join("stable.rs");
+        let other = repository_dir.as_ref().join("other.rs");
+
+        // `stable.rs` is last touched here, before the release.
+        fs_err::write(&stable, b"0").unwrap();
+        repo.add_all_and_commit("touch stable").unwrap();
+        let stable_commit = repo.current_commit_hash().unwrap();
+
+        // The release, then further history that does not touch `stable.rs`.
+        fs_err::write(&other, b"a").unwrap();
+        repo.add_all_and_commit("release").unwrap();
+        let release = repo.current_commit_hash().unwrap();
+        fs_err::write(&other, b"b").unwrap();
+        repo.add_all_and_commit("after release").unwrap();
+        let head = repo.current_commit_hash().unwrap();
+
+        // Simulate the caller checking out the last commit that touched `stable.rs` (older than
+        // the release) before computing the diff.
+        repo.checkout(&stable_commit).unwrap();
+
+        let commits = repo
+            .commits_at_paths_since(&head, &[&release], &[stable.as_ref()], u32::MAX)
+            .unwrap();
+        assert!(
+            commits.is_empty(),
+            "package unchanged since before the release should yield no commits, got {commits:?}"
+        );
     }
 
     #[test]

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -269,6 +269,12 @@ impl Repo {
         Ok(commit_list.lines().map(|c| c.to_string()).collect())
     }
 
+    /// The commit itself and all its ancestors, collected in one Git traversal.
+    pub fn ancestor_commits(&self, commit: &str) -> anyhow::Result<HashSet<String>> {
+        let commits = self.git(&["rev-list", commit])?;
+        Ok(commits.lines().map(str::to_owned).collect())
+    }
+
     #[instrument(skip(self))]
     pub fn checkout(&self, object: &str) -> anyhow::Result<()> {
         self.git(&["checkout", object])
@@ -632,6 +638,17 @@ mod tests {
         assert_eq!(commits.last(), Some(&base));
         assert!(commits.contains(&left));
         assert!(commits.contains(&right));
+
+        // An equal snapshot on the left must prune its ancestors without pruning its sibling.
+        let left_ancestors = repo.ancestor_commits(&left).unwrap();
+        assert!(left_ancestors.contains(&left));
+        assert!(left_ancestors.contains(&base));
+        assert!(left_ancestors.contains(&release));
+        assert!(!left_ancestors.contains(&right));
+        assert!(!left_ancestors.contains(&tip));
+        let merged_ancestors = repo.ancestor_commits(&tip).unwrap();
+        assert!(merged_ancestors.contains(&left));
+        assert!(merged_ancestors.contains(&right));
 
         let unlimited = repo
             .commits_at_paths_since(&tip, &[&release], &paths, Some(u32::MAX))

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -249,7 +249,7 @@ impl Repo {
         // `u32::MAX` means "no limit"; git's `--max-count` doesn't accept a value that large.
         let max_commits = (max_commits != u32::MAX).then(|| max_commits.to_string());
 
-        let mut git_args = vec!["log", "--format=%H"];
+        let mut git_args = vec!["log", "--topo-order", "--format=%H"];
         if let Some(max_commits) = &max_commits {
             git_args.push("--max-count");
             git_args.push(max_commits.as_str());

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -218,7 +218,8 @@ impl Repo {
         Ok(())
     }
 
-    /// Hashes of the commits that modified `paths`, from newest (`HEAD`) to oldest,
+    /// Hashes of the commits that modified `paths`, in reverse topological order
+    /// (descendants before ancestors),
     /// excluding any commit reachable from one of `boundary_commits` (typically the git tag
     /// and/or the commit at which the last version was published).
     ///
@@ -231,9 +232,9 @@ impl Repo {
     /// `head` must be the branch tip the changelog is being computed for (not necessarily the
     /// currently checked-out commit). Only boundary commits that are ancestors of `head` are
     /// used: a commit that isn't reachable from `head` (a newer release living on another
-    /// branch, a hash missing from a shallow clone, or simply the tag of a package unchanged
-    /// since before `head`) isn't a point `head` was released at, and excluding it would
-    /// wrongly drop the commits it shares with `head`. At most `max_commits` are returned.
+    /// branch or a hash missing from a shallow clone) isn't a point `head` was released at,
+    /// and excluding it would wrongly drop the commits it shares with `head`.
+    /// At most `max_commits` are returned.
     pub fn commits_at_paths_since(
         &self,
         head: &str,
@@ -585,6 +586,54 @@ mod tests {
                 !commits.contains(released),
                 "released commit {released} should not be collected, got {commits:?}"
             );
+        }
+    }
+
+    #[test]
+    fn commits_at_paths_since_orders_descendants_before_ancestors_with_clock_skew() {
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let release = repo.current_commit_hash().unwrap();
+        let commit_file = |name: &str, date: &str| {
+            fs_err::write(repo.directory().join(name), name).unwrap();
+            repo.add(&[name]).unwrap();
+            let output = Command::new("git")
+                .current_dir(repo.directory())
+                .env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_DATE", date)
+                .args(["commit", "-m", name])
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+            repo.current_commit_hash().unwrap()
+        };
+
+        let base = commit_file("base.rs", "2030-01-01T00:00:00Z");
+        repo.checkout_new_branch("left").unwrap();
+        let left = commit_file("left.rs", "2000-01-01T00:00:00Z");
+        repo.checkout(&base).unwrap();
+        repo.checkout_new_branch("right").unwrap();
+        let right = commit_file("right.rs", "2040-01-01T00:00:00Z");
+        repo.git(&["merge", "--no-ff", "left", "-m", "merge left"])
+            .unwrap();
+        let tip = repo.current_commit_hash().unwrap();
+        let paths = [repo.directory().as_std_path()];
+
+        let commits = repo
+            .commits_at_paths_since(&tip, &[&release], &paths, u32::MAX)
+            .unwrap();
+        // Date ordering would visit the shared base before the older left commit.
+        assert_eq!(commits.len(), 4);
+        assert_eq!(commits.first(), Some(&tip));
+        assert_eq!(commits.last(), Some(&base));
+        assert!(commits.contains(&left));
+        assert!(commits.contains(&right));
+
+        for limit in [0, 1, 2] {
+            let limited = repo
+                .commits_at_paths_since(&tip, &[&release], &paths, limit)
+                .unwrap();
+            assert_eq!(limited, commits[..limit as usize]);
         }
     }
 

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -234,33 +234,37 @@ impl Repo {
     /// used: a commit that isn't reachable from `head` (a newer release living on another
     /// branch or a hash missing from a shallow clone) isn't a point `head` was released at,
     /// and excluding it would wrongly drop the commits it shares with `head`.
-    /// At most `max_commits` are returned.
+    ///
+    /// `None` and `Some(u32::MAX)` mean unlimited; other values cap the number of commits.
     pub fn commits_at_paths_since(
         &self,
         head: &str,
         boundary_commits: &[&str],
         paths: &[&Path],
-        max_commits: u32,
+        max_commits: Option<u32>,
     ) -> anyhow::Result<Vec<String>> {
-        let excludes: Vec<String> = boundary_commits
-            .iter()
-            .filter(|commit| self.is_ancestor(commit, head))
-            .map(|commit| format!("^{commit}"))
-            .collect();
-        // `u32::MAX` means "no limit"; git's `--max-count` doesn't accept a value that large.
-        let max_commits = (max_commits != u32::MAX).then(|| max_commits.to_string());
-
-        let mut git_args = vec!["log", "--topo-order", "--format=%H"];
-        if let Some(max_commits) = &max_commits {
-            git_args.push("--max-count");
-            git_args.push(max_commits.as_str());
-        }
-        git_args.push(head);
-        git_args.extend(excludes.iter().map(String::as_str));
-        git_args.push("--");
-        for p in paths {
-            git_args.push(p.to_str().expect("invalid path"));
-        }
+        // Preserve the unlimited sentinel: Git cannot parse `u32::MAX` as `--max-count`.
+        let max_commits = max_commits.filter(|&n| n != u32::MAX);
+        let mut git_args = vec![
+            "log".to_string(),
+            "--topo-order".to_string(),
+            "--format=%H".to_string(),
+            head.to_string(),
+        ];
+        git_args.extend(max_commits.map(|n| format!("--max-count={n}")));
+        git_args.extend(
+            boundary_commits
+                .iter()
+                .filter(|commit| self.is_ancestor(commit, head))
+                .map(|commit| format!("^{commit}")),
+        );
+        git_args.push("--".to_string());
+        git_args.extend(
+            paths
+                .iter()
+                .map(|p| p.to_str().expect("invalid path").to_string()),
+        );
+        let git_args: Vec<&str> = git_args.iter().map(String::as_str).collect();
         let commit_list = self.git(&git_args)?;
         Ok(commit_list.lines().map(|c| c.to_string()).collect())
     }
@@ -569,7 +573,7 @@ mod tests {
             .unwrap();
 
         let commits = repo
-            .commits_at_paths_since("HEAD", &[&release], &[pkg.as_ref()], u32::MAX)
+            .commits_at_paths_since("HEAD", &[&release], &[pkg.as_ref()], None)
             .unwrap();
 
         // All three commits made after the release are collected, regardless of the branch
@@ -620,7 +624,7 @@ mod tests {
         let paths = [repo.directory().as_std_path()];
 
         let commits = repo
-            .commits_at_paths_since(&tip, &[&release], &paths, u32::MAX)
+            .commits_at_paths_since(&tip, &[&release], &paths, None)
             .unwrap();
         // Date ordering would visit the shared base before the older left commit.
         assert_eq!(commits.len(), 4);
@@ -629,9 +633,14 @@ mod tests {
         assert!(commits.contains(&left));
         assert!(commits.contains(&right));
 
+        let unlimited = repo
+            .commits_at_paths_since(&tip, &[&release], &paths, Some(u32::MAX))
+            .unwrap();
+        assert_eq!(unlimited, commits);
+
         for limit in [0, 1, 2] {
             let limited = repo
-                .commits_at_paths_since(&tip, &[&release], &paths, limit)
+                .commits_at_paths_since(&tip, &[&release], &paths, Some(limit))
                 .unwrap();
             assert_eq!(limited, commits[..limit as usize]);
         }
@@ -667,7 +676,7 @@ mod tests {
         let bogus = "0000000000000000000000000000000000000000";
         for boundary in [other.as_str(), bogus] {
             let commits = repo
-                .commits_at_paths_since("HEAD", &[boundary], &[file.as_ref()], u32::MAX)
+                .commits_at_paths_since("HEAD", &[boundary], &[file.as_ref()], None)
                 .unwrap();
             assert!(
                 commits.contains(&first) && commits.contains(&second),
@@ -706,7 +715,7 @@ mod tests {
         repo.checkout(&stable_commit).unwrap();
 
         let commits = repo
-            .commits_at_paths_since(&head, &[&release], &[stable.as_ref()], u32::MAX)
+            .commits_at_paths_since(&head, &[&release], &[stable.as_ref()], None)
             .unwrap();
         assert!(
             commits.is_empty(),

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -556,6 +556,10 @@ impl Updater<'_> {
         repository
             .checkout_head()
             .context("can't checkout head to calculate diff")?;
+        // The branch tip, captured before `checkout_last_commit_at_paths` moves `HEAD`.
+        let head = repository
+            .current_commit_hash()
+            .context("can't get HEAD commit to calculate diff")?;
         let registry_package = registry_packages.get_registry_package(&package.name);
         let mut diff = Diff::new(registry_package.is_some());
         let pathbufs_to_check = pathbufs_to_check(&package_path, package)?;
@@ -596,12 +600,40 @@ impl Updater<'_> {
                 );
             }
         }
+        // Collect the commits that touched the package since the last release, newest first.
+        // We bound the walk by the release commit(s) instead of walking commit by commit and
+        // stopping at the first already-released commit: with merge commits the latter can
+        // descend into a branch that forked before the release and rejoin already-released
+        // history, stopping early and dropping the commits that landed on the main line after
+        // the release (release-plz#2494).
+        let max_analyze_commits = if registry_package.is_none() {
+            match self.req.max_analyze_commits() {
+                0 => u32::MAX,
+                n => n,
+            }
+        } else {
+            u32::MAX
+        };
+        let release_boundaries: Vec<&str> = [
+            tag_commit.as_deref(),
+            registry_package.and_then(|p| p.published_at_sha1()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        let commits_to_analyze = repository.commits_at_paths_since(
+            &head,
+            &release_boundaries,
+            &paths_to_check,
+            max_analyze_commits,
+        )?;
+
         self.get_package_diff(
             &package_path,
             package,
             registry_package,
             repository,
-            tag_commit.as_deref(),
+            commits_to_analyze,
             &mut diff,
         )?;
 
@@ -617,23 +649,14 @@ impl Updater<'_> {
         package: &Package,
         registry_package: Option<&RegistryPackage>,
         repository: &Repo,
-        tag_commit: Option<&str>,
+        commits_to_analyze: Vec<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
-        let pathbufs_to_check = pathbufs_to_check(package_path, package)?;
-        let paths_to_check: Vec<&Path> = pathbufs_to_check.iter().map(|p| p.as_ref()).collect();
-        let max_analyze_commits = if registry_package.is_none() {
-            match self.req.max_analyze_commits() {
-                0 => u32::MAX,
-                n => n,
-            }
-        } else {
-            u32::MAX
-        };
-
-        for _ in 0..max_analyze_commits {
+        for current_commit_hash in commits_to_analyze {
+            // The info contained in `package` might be outdated after this checkout, because
+            // commits could contain changes to Cargo.toml.
+            repository.checkout(&current_commit_hash)?;
             let current_commit_message = repository.current_commit_message()?;
-            let current_commit_hash = repository.current_commit_hash()?;
 
             // Check if files changed in git commit belong to the current package.
             // This is required because a package can contain another package in a subdirectory.
@@ -642,10 +665,6 @@ impl Updater<'_> {
             };
 
             if let Some(registry_package) = registry_package {
-                debug!(
-                    "package {} found in cargo registry",
-                    registry_package.package.name
-                );
                 let registry_package_path = registry_package.package.package_path()?;
 
                 let are_packages_equal = self.check_package_equality(
@@ -654,55 +673,32 @@ impl Updater<'_> {
                     package_path,
                     registry_package_path,
                 ).with_context(|| format!("failed to check package equality for `{}` at commit {current_commit_hash}", package.name))?;
-                let commit_too_old = || {
-                    is_commit_too_old(
-                        repository,
-                        tag_commit,
-                        registry_package.published_at_sha1(),
-                        &current_commit_hash,
-                    )
-                };
-                if are_packages_equal || commit_too_old() {
+                if are_packages_equal {
+                    // The local package is identical to the registry one, so it was published
+                    // at this commit (e.g. later commits cancelled each other out). Everything
+                    // from here backwards is already released, so we stop.
                     debug!(
                         "next version calculated starting from commits after `{current_commit_hash}`"
                     );
-                    if diff.commits.is_empty() {
-                        // Even if the packages are equal, the Cargo.lock or Cargo.toml of the
-                        // workspace might have changed.
-                        // If the dependencies changed, we add a commit to the diff.
-                        self.add_dependencies_update_if_any(
-                            diff,
-                            &registry_package.package,
-                            package,
-                            registry_package_path,
-                        )?;
-                    }
-                    // The local package is identical to the registry one, which means that
-                    // the package was published at this commit, so we will not count this commit
-                    // as part of the release.
-                    // We can process the next package.
                     break;
-                } else {
-                    // When version is already bumped, we still collect commits to update the changelog,
-                    // but mark that version should not be bumped further.
-                    if package.version > registry_package.package.version
-                        && diff.is_version_published
-                    {
-                        info!(
-                            "{}: local version ({}) > registry version ({}). Only changelog will be updated.",
-                            package.name, package.version, registry_package.package.version
-                        );
-                        diff.set_version_unpublished(registry_package.package.version.clone());
-                    }
-                    if are_changed_files_in_pkg()? {
-                        debug!("packages contain different files");
-                        // At this point of the git history, the two packages are different,
-                        // which means that this commit is not present in the published package.
-                        diff.commits.push(Commit::new(
-                            current_commit_hash,
-                            current_commit_message.clone(),
-                        ));
-                    }
+                }
+                // When version is already bumped, we still collect commits to update the
+                // changelog, but mark that version should not be bumped further.
+                if package.version > registry_package.package.version && diff.is_version_published {
+                    info!(
+                        "{}: local version ({}) > registry version ({}). Only changelog will be updated.",
+                        package.name, package.version, registry_package.package.version
+                    );
+                    diff.set_version_unpublished(registry_package.package.version.clone());
+                }
+                if are_changed_files_in_pkg()? {
+                    debug!("packages contain different files");
+                    // The two packages are different, so this commit is not present in the
+                    // published package.
+                    diff.commits.push(Commit::new(
+                        current_commit_hash,
+                        current_commit_message.clone(),
+                    ));
                 }
             } else if are_changed_files_in_pkg()? {
                 diff.commits.push(Commit::new(
@@ -710,13 +706,20 @@ impl Updater<'_> {
                     current_commit_message.clone(),
                 ));
             }
-            // Go back to the previous commit.
-            // Keep in mind that the info contained in `package` might be outdated,
-            // because commits could contain changes to Cargo.toml.
-            if let Err(_err) = repository.checkout_previous_commit_at_paths(&paths_to_check) {
-                debug!("there are no other commits");
-                break;
-            }
+        }
+
+        // No package files changed since the last release, but the workspace `Cargo.lock` or
+        // `Cargo.toml` (i.e. the dependencies) might have. If so, we still add a commit.
+        if diff.commits.is_empty()
+            && let Some(registry_package) = registry_package
+        {
+            let registry_package_path = registry_package.package.package_path()?;
+            self.add_dependencies_update_if_any(
+                diff,
+                &registry_package.package,
+                package,
+                registry_package_path,
+            )?;
         }
         Ok(())
     }
@@ -917,37 +920,6 @@ fn get_package_files(
             Ok(relative_path.to_path_buf())
         })
         .collect()
-}
-
-/// Check if commit belongs to a previous version of the package.
-/// `tag_commit` is the commit hash of the tag of the previous version.
-/// `published_at_commit` is the commit hash where `cargo publish` ran.
-fn is_commit_too_old(
-    repository: &Repo,
-    tag_commit: Option<&str>,
-    published_at_commit: Option<&str>,
-    current_commit_hash: &str,
-) -> bool {
-    if let Some(tag_commit) = tag_commit.as_ref()
-        && repository.is_ancestor(current_commit_hash, tag_commit)
-    {
-        debug!(
-            "stopping looking at git history because the current commit ({}) is an ancestor of the commit ({}) tagged with the previous version.",
-            current_commit_hash, tag_commit
-        );
-        return true;
-    }
-
-    if let Some(published_commit) = published_at_commit.as_ref()
-        && repository.is_ancestor(current_commit_hash, published_commit)
-    {
-        debug!(
-            "stopping looking at git history because the current commit ({}) is an ancestor of the commit ({}) where the previous version was published.",
-            current_commit_hash, published_commit
-        );
-        return true;
-    }
-    false
 }
 
 fn pathbufs_to_check(

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -584,9 +584,6 @@ impl Updater<'_> {
         repository
             .checkout_head()
             .context("can't checkout head to calculate diff")?;
-        let head = repository
-            .current_commit_hash()
-            .context("can't get HEAD commit to calculate diff")?;
         let registry_package = registry_packages.get_registry_package(&package.name);
         let mut diff = Diff::new(registry_package.is_some());
         let pathbufs_to_check = pathbufs_to_check(&package_path, package)?;
@@ -614,19 +611,11 @@ impl Updater<'_> {
                 );
             }
         }
-        // Collect the commits that touched the package since the last release, newest first.
-        // We bound the walk by the release commit(s) instead of walking commit by commit and
-        // stopping at the first already-released commit: with merge commits the latter can
-        // descend into a branch that forked before the release and rejoin already-released
-        // history, stopping early and dropping the commits that landed on the main line after
-        // the release (release-plz#2494).
-        let max_analyze_commits = if registry_package.is_none() {
-            match self.req.max_analyze_commits() {
-                0 => u32::MAX,
-                n => n,
-            }
-        } else {
-            u32::MAX
+        // Without a registry package there is no release boundary, so the walk is capped by
+        // `max_analyze_commits` (0 means unlimited).
+        let max_commits = match (registry_package, self.req.max_analyze_commits()) {
+            (None, n) if n > 0 => Some(n),
+            _ => None,
         };
         let release_boundaries: Vec<&str> = [
             tag_commit.as_deref(),
@@ -635,11 +624,13 @@ impl Updater<'_> {
         .into_iter()
         .flatten()
         .collect();
+        // See `commits_at_paths_since` for why the walk is bounded by the release commits
+        // instead of stopping at the first already-released commit (release-plz#2494).
         let commits_to_analyze = repository.commits_at_paths_since(
-            &head,
+            repository.original_branch(),
             &release_boundaries,
             &paths_to_check,
-            max_analyze_commits,
+            max_commits,
         )?;
 
         self.get_package_diff(
@@ -664,16 +655,35 @@ impl Updater<'_> {
         commits_to_analyze: Vec<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
-        // Compare the final tree first: a change followed by a revert must not
-        // trigger a release. An equal tree on a merged branch, however, must not
-        // stop traversal of its siblings.
-        if let Some(registry_package) = registry_package
-            && self.check_package_equality(
+        // Compare the final tree first: a change followed by a revert must not trigger a
+        // release, no matter what happened in between.
+        let is_head_equal_to_registry = match registry_package {
+            Some(registry_package) => self.check_package_equality(
                 repository,
                 package,
                 package_path,
                 registry_package.package.package_path()?,
-            )?
+            )?,
+            None => false,
+        };
+        if !is_head_equal_to_registry {
+            self.collect_commits(
+                package_path,
+                package,
+                registry_package,
+                repository,
+                commits_to_analyze,
+                diff,
+            )?;
+        }
+        repository
+            .checkout_head()
+            .context("can't checkout to head after calculating diff")?;
+
+        // No package files changed since the last release, but the workspace `Cargo.lock` or
+        // `Cargo.toml` (i.e. the dependencies) might have. If so, we still add a commit.
+        if diff.commits.is_empty()
+            && let Some(registry_package) = registry_package
         {
             self.add_dependencies_update_if_any(
                 diff,
@@ -681,41 +691,45 @@ impl Updater<'_> {
                 package,
                 registry_package.package.package_path()?,
             )?;
-            return Ok(());
         }
+        Ok(())
+    }
 
-        let mut equal_boundaries: Vec<String> = Vec::new();
+    /// Check out each commit in `commits_to_analyze` (newest first) and add to `diff` the
+    /// ones that changed the package with respect to the registry.
+    fn collect_commits(
+        &self,
+        package_path: &Utf8Path,
+        package: &Package,
+        registry_package: Option<&RegistryPackage>,
+        repository: &Repo,
+        commits_to_analyze: Vec<String>,
+        diff: &mut Diff,
+    ) -> anyhow::Result<()> {
+        // Commits where the package is equal to the registry one. Their ancestors are already
+        // released, but sibling branches can still contain unreleased work, so the walk goes
+        // on and only skips them.
+        let mut released_commits: Vec<String> = Vec::new();
         for current_commit_hash in commits_to_analyze {
-            if equal_boundaries
+            if released_commits
                 .iter()
-                .any(|boundary| repository.is_ancestor(&current_commit_hash, boundary))
+                .any(|released| repository.is_ancestor(&current_commit_hash, released))
             {
                 continue;
             }
             // The info contained in `package` might be outdated after this checkout, because
             // commits could contain changes to Cargo.toml.
             repository.checkout(&current_commit_hash)?;
-            let current_commit_message = repository.current_commit_message()?;
-
-            // Check if files changed in git commit belong to the current package.
-            // This is required because a package can contain another package in a subdirectory.
-            let are_changed_files_in_pkg = || {
-                self.are_changed_files_in_package(package_path, repository, &current_commit_hash)
-            };
 
             if let Some(registry_package) = registry_package {
-                let registry_package_path = registry_package.package.package_path()?;
-
                 let are_packages_equal = self.check_package_equality(
                     repository,
                     package,
                     package_path,
-                    registry_package_path,
+                    registry_package.package.package_path()?,
                 ).with_context(|| format!("failed to check package equality for `{}` at commit {current_commit_hash}", package.name))?;
                 if are_packages_equal {
-                    // Exclude this snapshot and its ancestors, but keep walking
-                    // independent branches that can still contain unreleased work.
-                    equal_boundaries.push(current_commit_hash);
+                    released_commits.push(current_commit_hash);
                     continue;
                 }
                 // When version is already bumped, we still collect commits to update the
@@ -727,39 +741,15 @@ impl Updater<'_> {
                     );
                     diff.set_version_unpublished(registry_package.package.version.clone());
                 }
-                if are_changed_files_in_pkg()? {
-                    debug!("packages contain different files");
-                    // The two packages are different, so this commit is not present in the
-                    // published package.
-                    diff.commits.push(Commit::new(
-                        current_commit_hash,
-                        current_commit_message.clone(),
-                    ));
-                }
-            } else if are_changed_files_in_pkg()? {
+            }
+            // Check if files changed in git commit belong to the current package.
+            // This is required because a package can contain another package in a subdirectory.
+            if self.are_changed_files_in_package(package_path, repository, &current_commit_hash)? {
                 diff.commits.push(Commit::new(
                     current_commit_hash,
-                    current_commit_message.clone(),
+                    repository.current_commit_message()?,
                 ));
             }
-        }
-
-        repository
-            .checkout_head()
-            .context("can't checkout to head after calculating diff")?;
-
-        // No package files changed since the last release, but the workspace `Cargo.lock` or
-        // `Cargo.toml` (i.e. the dependencies) might have. If so, we still add a commit.
-        if diff.commits.is_empty()
-            && let Some(registry_package) = registry_package
-        {
-            let registry_package_path = registry_package.package.package_path()?;
-            self.add_dependencies_update_if_any(
-                diff,
-                &registry_package.package,
-                package,
-                registry_package_path,
-            )?;
         }
         Ok(())
     }

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -626,12 +626,14 @@ impl Updater<'_> {
         .collect();
         // See `commits_at_paths_since` for why the walk is bounded by the release commits
         // instead of stopping at the first already-released commit (release-plz#2494).
-        let commits_to_analyze = repository.commits_at_paths_since(
-            repository.original_branch(),
-            &release_boundaries,
-            &paths_to_check,
-            max_commits,
-        )?;
+        let commits_to_analyze = || {
+            repository.commits_at_paths_since(
+                repository.original_branch(),
+                &release_boundaries,
+                &paths_to_check,
+                max_commits,
+            )
+        };
 
         self.get_package_diff(
             &package_path,
@@ -652,11 +654,11 @@ impl Updater<'_> {
         package: &Package,
         registry_package: Option<&RegistryPackage>,
         repository: &Repo,
-        commits_to_analyze: Vec<String>,
+        commits_to_analyze: impl FnOnce() -> anyhow::Result<Vec<String>>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
         // Compare the final tree first: a change followed by a revert must not trigger a
-        // release, no matter what happened in between.
+        // release, no matter what happened in between. Collect history only if it differs.
         let is_head_equal_to_registry = match registry_package {
             Some(registry_package) => self.check_package_equality(
                 repository,
@@ -672,7 +674,7 @@ impl Updater<'_> {
                 package,
                 registry_package,
                 repository,
-                commits_to_analyze,
+                commits_to_analyze()?,
                 diff,
             )?;
         }
@@ -706,15 +708,12 @@ impl Updater<'_> {
         commits_to_analyze: Vec<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
-        // Commits where the package is equal to the registry one. Their ancestors are already
-        // released, but sibling branches can still contain unreleased work, so the walk goes
-        // on and only skips them.
-        let mut released_commits: Vec<String> = Vec::new();
+        // An equal snapshot and its ancestors are already released. Collect those ancestors
+        // in bulk so skipping old history does not require a Git process per commit.
+        // Sibling branches can still contain unreleased work and must be checked.
+        let mut released_commits = HashSet::new();
         for current_commit_hash in commits_to_analyze {
-            if released_commits
-                .iter()
-                .any(|released| repository.is_ancestor(&current_commit_hash, released))
-            {
+            if released_commits.contains(&current_commit_hash) {
                 continue;
             }
             // The info contained in `package` might be outdated after this checkout, because
@@ -729,7 +728,7 @@ impl Updater<'_> {
                     registry_package.package.package_path()?,
                 ).with_context(|| format!("failed to check package equality for `{}` at commit {current_commit_hash}", package.name))?;
                 if are_packages_equal {
-                    released_commits.push(current_commit_hash);
+                    released_commits.extend(repository.ancestor_commits(&current_commit_hash)?);
                     continue;
                 }
                 // When version is already bumped, we still collect commits to update the
@@ -1184,14 +1183,16 @@ mod tests {
                 &package,
                 Some(&published),
                 &repo,
-                vec![
-                    tip,
-                    branch,
-                    equal,
-                    wanted.clone(),
-                    temporary.clone(),
-                    base.clone(),
-                ],
+                || {
+                    Ok(vec![
+                        tip,
+                        branch,
+                        equal,
+                        wanted.clone(),
+                        temporary.clone(),
+                        base.clone(),
+                    ])
+                },
                 &mut diff,
             )
             .unwrap();
@@ -1223,7 +1224,7 @@ mod tests {
                 &package,
                 Some(&published),
                 &repo,
-                vec![repo.current_commit_hash().unwrap(), wanted],
+                || panic!("an unchanged package must not collect Git history"),
                 &mut diff,
             )
             .unwrap();

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -1223,6 +1223,21 @@ mod tests {
         assert!(diff.commits.iter().any(|commit| commit.id == wanted));
         assert!(!diff.commits.iter().any(|commit| commit.id == temporary));
 
+        // Exercise the actual Git walk too, both with a known publication commit
+        // and with package equality as the only release boundary.
+        for published_at in [None, Some(base.clone())] {
+            let registry = PackagesCollection::default().with_packages(
+                [(
+                    package.name.to_string(),
+                    RegistryPackage::new(published.package.clone(), published_at),
+                )]
+                .into(),
+            );
+            let diff = updater.get_diff(&package, &registry, &repo).unwrap();
+            assert!(diff.commits.iter().any(|commit| commit.id == wanted));
+            assert!(!diff.commits.iter().any(|commit| commit.id == temporary));
+        }
+
         // A final tree equal to the registry remains a no-op, even if history differs.
         repo.git(&["read-tree", "--reset", "-u", &base]).unwrap();
         repo.add_all_and_commit("revert all changes").unwrap();

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -680,7 +680,35 @@ impl Updater<'_> {
         commits_to_analyze: Vec<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
+        // Compare the final tree first: a change followed by a revert must not
+        // trigger a release. An equal tree on a merged branch, however, must not
+        // stop traversal of its siblings.
+        repository.checkout_head()?;
+        if let Some(registry_package) = registry_package
+            && self.check_package_equality(
+                repository,
+                package,
+                package_path,
+                registry_package.package.package_path()?,
+            )?
+        {
+            self.add_dependencies_update_if_any(
+                diff,
+                &registry_package.package,
+                package,
+                registry_package.package.package_path()?,
+            )?;
+            return Ok(());
+        }
+
+        let mut equal_boundaries: Vec<String> = Vec::new();
         for current_commit_hash in commits_to_analyze {
+            if equal_boundaries
+                .iter()
+                .any(|boundary| repository.is_ancestor(&current_commit_hash, boundary))
+            {
+                continue;
+            }
             // The info contained in `package` might be outdated after this checkout, because
             // commits could contain changes to Cargo.toml.
             repository.checkout(&current_commit_hash)?;
@@ -702,13 +730,10 @@ impl Updater<'_> {
                     registry_package_path,
                 ).with_context(|| format!("failed to check package equality for `{}` at commit {current_commit_hash}", package.name))?;
                 if are_packages_equal {
-                    // The local package is identical to the registry one, so it was published
-                    // at this commit (e.g. later commits cancelled each other out). Everything
-                    // from here backwards is already released, so we stop.
-                    debug!(
-                        "next version calculated starting from commits after `{current_commit_hash}`"
-                    );
-                    break;
+                    // Exclude this snapshot and its ancestors, but keep walking
+                    // independent branches that can still contain unreleased work.
+                    equal_boundaries.push(current_commit_hash);
+                    continue;
                 }
                 // When version is already bumped, we still collect commits to update the
                 // changelog, but mark that version should not be bumped further.
@@ -735,6 +760,8 @@ impl Updater<'_> {
                 ));
             }
         }
+
+        repository.checkout_head()?;
 
         // No package files changed since the last release, but the workspace `Cargo.lock` or
         // `Cargo.toml` (i.e. the dependencies) might have. If so, we still add a commit.
@@ -1097,6 +1124,121 @@ fn get_repo_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Package equality on one branch cannot terminate the sibling traversal.
+    #[test]
+    fn equal_branch_snapshot_does_not_hide_sibling_changes() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let registry_dir = tempfile::tempdir().unwrap();
+        let repo = Repo::init(&local_dir);
+        let registry_repo = Repo::init(&registry_dir);
+        let manifest =
+            "[package]\nname = \"history-test\"\nversion = \"0.1.0\"\nedition = \"2021\"\n";
+        for root in [repo.directory(), registry_repo.directory()] {
+            fs_err::create_dir(root.join("src")).unwrap();
+            fs_err::write(root.join(CARGO_TOML), manifest).unwrap();
+            fs_err::write(root.join("src/lib.rs"), "pub fn base() {}\n").unwrap();
+            fs_err::write(root.join(".gitignore"), "/target\n").unwrap();
+        }
+        for root in [repo.directory(), registry_repo.directory()] {
+            cargo_utils::get_manifest_metadata(&root.join(CARGO_TOML)).unwrap();
+        }
+        repo.add_all_and_commit("base").unwrap();
+        registry_repo.add_all_and_commit("published base").unwrap();
+        let base = repo.current_commit_hash().unwrap();
+        let main_branch = repo.original_branch().to_string();
+
+        repo.git(&["checkout", "-b", "sibling"]).unwrap();
+        fs_err::write(
+            repo.directory().join("src/lib.rs"),
+            "pub fn temporary() {}\n",
+        )
+        .unwrap();
+        repo.add_all_and_commit("fix: temporary").unwrap();
+        let temporary = repo.current_commit_hash().unwrap();
+        fs_err::write(repo.directory().join("src/lib.rs"), "pub fn base() {}\n").unwrap();
+        repo.add_all_and_commit("revert: temporary").unwrap();
+        let equal = repo.current_commit_hash().unwrap();
+        fs_err::write(
+            repo.directory().join("src/branch.rs"),
+            "pub fn branch() {}\n",
+        )
+        .unwrap();
+        repo.add_all_and_commit("fix: branch").unwrap();
+        let branch = repo.current_commit_hash().unwrap();
+
+        repo.checkout(&main_branch).unwrap();
+        fs_err::write(
+            repo.directory().join("src/wanted.rs"),
+            "pub fn wanted() {}\n",
+        )
+        .unwrap();
+        repo.add_all_and_commit("fix: wanted sibling").unwrap();
+        let wanted = repo.current_commit_hash().unwrap();
+        repo.git(&["merge", "--no-ff", "sibling", "-m", "merge sibling"])
+            .unwrap();
+        let tip = repo.current_commit_hash().unwrap();
+
+        let metadata =
+            cargo_utils::get_manifest_metadata(&repo.directory().join(CARGO_TOML)).unwrap();
+        let package = metadata.root_package().unwrap().clone();
+        let request = UpdateRequest::new(metadata.clone()).unwrap();
+        let project = Project::new(
+            request.local_manifest(),
+            None,
+            &HashSet::new(),
+            &metadata,
+            &request,
+        )
+        .unwrap();
+        let updater = Updater {
+            project: &project,
+            req: &request,
+        };
+        let registry_metadata =
+            cargo_utils::get_manifest_metadata(&registry_repo.directory().join(CARGO_TOML))
+                .unwrap();
+        fs_err::write(registry_repo.directory().join("Cargo.toml.orig"), manifest).unwrap();
+        let published =
+            RegistryPackage::new(registry_metadata.root_package().unwrap().clone(), None);
+        let mut diff = Diff::new(true);
+        // A valid topological order which visits the equal branch before its sibling.
+        updater
+            .get_package_diff(
+                repo.directory(),
+                &package,
+                Some(&published),
+                &repo,
+                vec![
+                    tip,
+                    branch,
+                    equal,
+                    wanted.clone(),
+                    temporary.clone(),
+                    base.clone(),
+                ],
+                &mut diff,
+            )
+            .unwrap();
+        assert!(diff.commits.iter().any(|commit| commit.id == wanted));
+        assert!(!diff.commits.iter().any(|commit| commit.id == temporary));
+
+        // A final tree equal to the registry remains a no-op, even if history differs.
+        repo.git(&["read-tree", "--reset", "-u", &base]).unwrap();
+        repo.add_all_and_commit("revert all changes").unwrap();
+        let mut diff = Diff::new(true);
+        updater
+            .get_package_diff(
+                repo.directory(),
+                &package,
+                Some(&published),
+                &repo,
+                vec![repo.current_commit_hash().unwrap(), wanted],
+                &mut diff,
+            )
+            .unwrap();
+        assert!(diff.commits.is_empty());
+    }
 
     #[test]
     fn same_version_is_not_added_to_changelog() {

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -584,7 +584,6 @@ impl Updater<'_> {
         repository
             .checkout_head()
             .context("can't checkout head to calculate diff")?;
-        // The branch tip, captured before `checkout_last_commit_at_paths` moves `HEAD`.
         let head = repository
             .current_commit_hash()
             .context("can't get HEAD commit to calculate diff")?;
@@ -592,19 +591,6 @@ impl Updater<'_> {
         let mut diff = Diff::new(registry_package.is_some());
         let pathbufs_to_check = pathbufs_to_check(&package_path, package)?;
         let paths_to_check: Vec<&Path> = pathbufs_to_check.iter().map(|p| p.as_ref()).collect();
-        repository
-            .checkout_last_commit_at_paths(&paths_to_check)
-            .map_err(|err| {
-                if err
-                    .to_string()
-                    .contains("Your local changes to the following files would be overwritten")
-                {
-                    err.context("The allow-dirty option can't be used in this case")
-                } else {
-                    err.context("Failed to retrieve the last commit of local repository.")
-                }
-            })?;
-
         let git_tag = self
             .project
             .git_tag(&package.name, &package.version.to_string())?;
@@ -665,12 +651,10 @@ impl Updater<'_> {
             &mut diff,
         )?;
 
-        repository
-            .checkout_head()
-            .context("can't checkout to head after calculating diff")?;
         Ok(diff)
     }
 
+    /// Requires the repository to be at its branch head and restores it after traversal.
     fn get_package_diff(
         &self,
         package_path: &Utf8Path,
@@ -683,7 +667,6 @@ impl Updater<'_> {
         // Compare the final tree first: a change followed by a revert must not
         // trigger a release. An equal tree on a merged branch, however, must not
         // stop traversal of its siblings.
-        repository.checkout_head()?;
         if let Some(registry_package) = registry_package
             && self.check_package_equality(
                 repository,
@@ -761,7 +744,9 @@ impl Updater<'_> {
             }
         }
 
-        repository.checkout_head()?;
+        repository
+            .checkout_head()
+            .context("can't checkout to head after calculating diff")?;
 
         // No package files changed since the last release, but the workspace `Cargo.lock` or
         // `Cargo.toml` (i.e. the dependencies) might have. If so, we still add a commit.
@@ -1130,8 +1115,8 @@ mod tests {
     fn equal_branch_snapshot_does_not_hide_sibling_changes() {
         let local_dir = tempfile::tempdir().unwrap();
         let registry_dir = tempfile::tempdir().unwrap();
-        let repo = Repo::init(&local_dir);
-        let registry_repo = Repo::init(&registry_dir);
+        let repo = Repo::init(dunce::canonicalize(local_dir.path()).unwrap());
+        let registry_repo = Repo::init(dunce::canonicalize(registry_dir.path()).unwrap());
         let manifest =
             "[package]\nname = \"history-test\"\nversion = \"0.1.0\"\nedition = \"2021\"\n";
         for root in [repo.directory(), registry_repo.directory()] {


### PR DESCRIPTION
The changelog walk checked out the package at each commit and moved to the
"previous commit at paths", re-anchored at the just checked-out commit, stopping
as soon as a commit was an ancestor of the last release's tag.

With a merge commit whose branch forked before the last release and merged after
it, that walk descends into the merged branch, reaches a commit that predates the
release, and stops, silently dropping every commit that landed on the main line
between the release and the merge.

Collect the commits in one pass instead, bounding the walk by the release
commit(s): `git log <tip> ^<tag> ^<published> -- <paths>`, where `<tip>` is the
branch tip captured *before* the diff checks out the package's last-touching
commit. Using the branch tip rather than the ambient `HEAD` is essential: for a
package left untouched since before the release, `HEAD` sits at an old commit the
release tag isn't an ancestor of, so the boundary would be dropped and the walk
would dump the package's entire history. For the same reason only boundaries that
are ancestors of the tip are used, so a newer version published on another branch
(or a hash missing from a shallow clone) can't wrongly exclude the commits it
shares with the tip. Package equality is still checked per commit, so a net-zero
change since the release produces no release.

Fixes #2494.

- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

While preparing for the most recent zbus releases, I noticed after
merging [the PR][1] from `release-plz update` results that the changelog was
missing a few commits that really shouldn't have been filtered out. So I
[manually updated the changelog][2] to add the missing entries and since I
didn't have much time (it was a Fri night after all), I let Claude Code
investigate and fix it. While this whole commit is a result of that, I did
however, looked at the code and AFAICT, it looks good and I also manually
tested it and can verify that it works.

[1]: https://github.com/z-galaxy/zbus/pull/1857
[2]: https://github.com/z-galaxy/zbus/pull/1858
