### PR TITLE
fix(package_compare): skip cargo package --list when Cargo.toml.orig exists

### DIFF
--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -109,12 +109,11 @@ pub fn get_cargo_package_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8Pat
     // TODO: Do this always, not only if we are in target/package.
     //       See https://github.com/release-plz/release-plz/issues/2130
     info!("Getting packaged files for crate at {}", package);
-    if is_cargo_packaged_dir(package)
-        && (package.join("Cargo.toml.orig").exists()
-            || package.join("Cargo.toml.orig.orig").exists())
+    if package.join("Cargo.toml.orig").exists()
+        || package.join("Cargo.toml.orig.orig").exists()
     {
-        let list =
-            list_packaged_files(package).context("cannot list packaged files from directory")?;
+        let list = list_packaged_files(package)
+            .context("cannot list packaged files from directory")?;
         debug!("Packaged files: {:?}", list);
         Ok(list)
     } else {
@@ -138,13 +137,6 @@ fn get_cargo_package_list(package: &Utf8Path) -> Result<Vec<Utf8PathBuf>, anyhow
 
     let files = output.stdout.lines().map(Utf8PathBuf::from).collect();
     Ok(files)
-}
-
-fn is_cargo_packaged_dir(package: &Utf8Path) -> bool {
-    package.ancestors().any(|ancestor| {
-        ancestor.file_name() == Some("package")
-            && ancestor.parent().and_then(|parent| parent.file_name()) == Some("target")
-    })
 }
 
 fn list_packaged_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {


### PR DESCRIPTION
Fixes #2130

### What changed
- If `Cargo.toml.orig` or `Cargo.toml.orig.orig` is present, list packaged files directly from disk.
- Removed the additional `target/package` ancestry guard that prevented disk-based listing in local package workflows.
- Removed unused helper `is_cargo_packaged_dir`.

### Why
- The `cargo package --list` call is unnecessary and brittle when `Cargo.toml.orig` shows the crate came from registry packaging.

### Risk
- Small behavior change: local/registry-packaged crates now follow the faster disk-listing path; tests pass with `cargo check -p release_plz_core` locally.