### PR TITLE
perf(git-only): reuse historical workspace packaging

### DIFF
--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -922,7 +922,96 @@ publish = false
 
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
-async fn git_only_update_handles_workspace_path_dependencies() {
+async fn git_only_update_handles_workspace_path_dependencies_at_different_commits() {
+    let context = TestContext::new_workspace_with_packages(&[
+        TestPackage::new("mylib").with_type(PackageType::Lib),
+        TestPackage::new("mybin")
+            .with_type(PackageType::Bin)
+            .with_path_dependencies(vec!["../mylib"]),
+    ])
+    .await;
+
+    let config = r#"
+[workspace]
+git_only = true
+publish = false
+"#;
+    context.write_release_plz_toml(config);
+
+    context
+        .repo
+        .tag("mylib-v0.1.0", "Release mylib v0.1.0")
+        .unwrap();
+
+    // Release the binary at a later commit with different package contents, so
+    // each package must be compared against its own historical workspace.
+    let readme = context.package_path("mybin").join("README.md");
+    fs_err::write(&readme, "# Initial mybin release").unwrap();
+    context.push_all_changes("feat: prepare mybin release");
+    context
+        .repo
+        .tag("mybin-v0.1.0", "Release mybin v0.1.0")
+        .unwrap();
+
+    fs_err::write(&readme, "# Updated README").unwrap();
+    context.push_all_changes("fix: update mybin readme");
+
+    let outcome = context
+        .run_release_pr_with_log("DEBUG,hyper=INFO")
+        .success();
+    let stderr = String::from_utf8_lossy(&outcome.get_output().stderr);
+    assert_eq!(
+        stderr
+            .matches("Run `cargo package --allow-dirty --workspace`")
+            .count(),
+        2,
+        "packages at different historical commits need separate workspace reconstructions\n{stderr}"
+    );
+
+    let opened_prs = context.opened_release_prs().await;
+    assert_eq!(opened_prs.len(), 1);
+
+    let pr_body = opened_prs[0].body.as_ref().expect("PR should have body");
+
+    let today = today();
+    let username = context.gitea.user.username();
+    let repo = &context.gitea.repo;
+    assert_eq!(
+        format!(
+            r"
+## 🤖 New release
+
+* `mybin`: 0.1.0 -> 0.1.1
+
+<details><summary><i><b>Changelog</b></i></summary><p>
+
+<blockquote>
+
+## [0.1.1](https://localhost:3000/{username}/{repo}/compare/mybin-v0.1.0...mybin-v0.1.1) - {today}
+
+### Fixed
+
+- update mybin readme
+</blockquote>
+
+
+</p></details>
+
+---
+This PR was generated with [release-plz](https://github.com/release-plz/release-plz/)."
+        )
+        .trim(),
+        pr_body.trim()
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn git_only_update_handles_packages_sharing_a_release_tag() {
+    // All packages are released together under a single workspace tag, so they
+    // are all resolved at the same historical commit.
+    // The unreleased internal libraries are path dependencies of the binary, so
+    // the whole workspace must be packaged at that commit.
     let context = TestContext::new_workspace_with_packages(&[
         TestPackage::new("mylib-a").with_type(PackageType::Lib),
         TestPackage::new("mylib-b").with_type(PackageType::Lib),

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -932,18 +932,11 @@ async fn git_only_update_handles_workspace_path_dependencies() {
     ])
     .await;
 
-    for package in ["mylib-a", "mylib-b"] {
-        let manifest_path = context.package_path(package).join("Cargo.toml");
-        let mut manifest = cargo_utils::LocalManifest::try_new(&manifest_path).unwrap();
-        manifest.data["package"]["publish"] = false.into();
-        manifest.write().unwrap();
-    }
-    context.push_all_changes("chore: make internal libraries unpublished");
-
     let config = r#"
 [workspace]
 git_only = true
 publish = false
+git_tag_name = "v{{ version }}"
 "#;
     context.write_release_plz_toml(config);
 

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -924,12 +924,21 @@ publish = false
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn git_only_update_handles_workspace_path_dependencies() {
     let context = TestContext::new_workspace_with_packages(&[
-        TestPackage::new("mylib").with_type(PackageType::Lib),
+        TestPackage::new("mylib-a").with_type(PackageType::Lib),
+        TestPackage::new("mylib-b").with_type(PackageType::Lib),
         TestPackage::new("mybin")
             .with_type(PackageType::Bin)
-            .with_path_dependencies(vec!["../mylib"]),
+            .with_path_dependencies(vec!["../mylib-a", "../mylib-b"]),
     ])
     .await;
+
+    for package in ["mylib-a", "mylib-b"] {
+        let manifest_path = context.package_path(package).join("Cargo.toml");
+        let mut manifest = cargo_utils::LocalManifest::try_new(&manifest_path).unwrap();
+        manifest.data["package"]["publish"] = false.into();
+        manifest.write().unwrap();
+    }
+    context.push_all_changes("chore: make internal libraries unpublished");
 
     let config = r#"
 [workspace]
@@ -940,7 +949,11 @@ publish = false
 
     context
         .repo
-        .tag("mylib-v0.1.0", "Release mylib v0.1.0")
+        .tag("mylib-a-v0.1.0", "Release mylib-a v0.1.0")
+        .unwrap();
+    context
+        .repo
+        .tag("mylib-b-v0.1.0", "Release mylib-b v0.1.0")
         .unwrap();
     context
         .repo
@@ -951,7 +964,17 @@ publish = false
     fs_err::write(&readme, "# Updated README").unwrap();
     context.push_all_changes("fix: update mybin readme");
 
-    context.run_release_pr().success();
+    let outcome = context
+        .run_release_pr_with_log("DEBUG,hyper=INFO")
+        .success();
+    let stderr = String::from_utf8_lossy(&outcome.get_output().stderr);
+    assert_eq!(
+        stderr
+            .matches("Run `cargo package --allow-dirty --workspace`")
+            .count(),
+        1,
+        "packages at one historical commit should share workspace reconstruction\n{stderr}"
+    );
 
     let opened_prs = context.opened_release_prs().await;
     assert_eq!(opened_prs.len(), 1);

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -949,15 +949,7 @@ publish = false
 
     context
         .repo
-        .tag("mylib-a-v0.1.0", "Release mylib-a v0.1.0")
-        .unwrap();
-    context
-        .repo
-        .tag("mylib-b-v0.1.0", "Release mylib-b v0.1.0")
-        .unwrap();
-    context
-        .repo
-        .tag("mybin-v0.1.0", "Release mybin v0.1.0")
+        .tag("v0.1.0", "Release workspace v0.1.0")
         .unwrap();
 
     let readme = context.package_path("mybin").join("README.md");

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -980,7 +980,7 @@ git_tag_name = "v{{ version }}"
 
 <blockquote>
 
-## [0.1.1](https://localhost:3000/{username}/{repo}/compare/mybin-v0.1.0...mybin-v0.1.1) - {today}
+## [0.1.1](https://localhost:3000/{username}/{repo}/compare/v0.1.0...v0.1.1) - {today}
 
 ### Fixed
 

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -195,9 +195,13 @@ impl TestContext {
     }
 
     pub fn run_release_pr(&self) -> Assert {
+        self.run_release_pr_with_log(&log_level())
+    }
+
+    pub fn run_release_pr_with_log(&self, log: &str) -> Assert {
         super::cmd::release_plz_cmd(&self.cargo_target_dir())
             .current_dir(self.repo_dir())
-            .env(RELEASE_PLZ_LOG, log_level())
+            .env(RELEASE_PLZ_LOG, log)
             .arg("release-pr")
             .arg("--verbose")
             .arg("--git-token")

--- a/crates/release_plz_core/src/command/release_pr/git.rs
+++ b/crates/release_plz_core/src/command/release_pr/git.rs
@@ -176,44 +176,6 @@ impl GitRepo {
         branch.delete().context("delete branch")?;
         Ok(())
     }
-
-    /// Clean up existing worktree and its branch if they exist
-    pub fn cleanup_worktree_if_exists(&mut self, name: &str) -> anyhow::Result<()> {
-        let trees: Vec<String> = self
-            .repo
-            .worktrees()
-            .context("get worktrees for repo")?
-            .iter()
-            .filter_map(|x| x.ok().flatten().map(ToString::to_string))
-            .collect();
-
-        if trees.contains(&name.to_string()) {
-            debug!("Worktree {name} already exists, cleaning it up");
-
-            // Find the worktree
-            let wt = match self.repo.find_worktree(name) {
-                Ok(wt) => wt,
-                Err(e) => {
-                    warn!("Error finding worktree {name} for cleanup: {e:?}");
-                    return Ok(());
-                }
-            };
-
-            // Prune the worktree
-            if let Err(e) = wt.prune(Some(
-                WorktreePruneOptions::new().working_tree(true).valid(true),
-            )) {
-                warn!("Error pruning worktree {name}: {e:?}");
-            }
-
-            // Delete the branch
-            if let Err(e) = self.delete_branch(name) {
-                warn!("Error deleting branch {name}: {e:?}");
-            }
-        }
-
-        Ok(())
-    }
 }
 
 /// We maintain a handle to the temp dir so it doesn't delete itself before the worktree is cleaned

--- a/crates/release_plz_core/src/command/release_pr/git.rs
+++ b/crates/release_plz_core/src/command/release_pr/git.rs
@@ -35,19 +35,22 @@ impl GitRepo {
             .prefix(&prefix)
             .tempdir()
             .context("create temporary directory for worktree")?;
+        let random_suffix = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("get temporary worktree directory name")?;
+        let unique_name = format!("{name}-{random_suffix}");
 
         // Append "worktree" to get a path that doesn't exist yet (git worktree will create it)
         let temp_base = to_utf8_path(temp_dir.path())?;
         let path = temp_base.join("worktree");
         let path_std = path.as_std_path();
 
-        // Clean up existing worktree if it exists
-        self.cleanup_worktree_if_exists(name)?;
-
-        debug!("Creating worktree called {name} at {path}");
+        debug!("Creating worktree called {unique_name} at {path}");
         let wt = self
             .repo
-            .worktree(name, path_std, None)
+            .worktree(&unique_name, path_std, None)
             .with_context(|| format!("create worktree at {path}"))?;
         Ok(GitWorkTree {
             worktree: wt,

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -1,4 +1,4 @@
-use crate::cargo::run_cargo;
+use crate::cargo::run_cargo_with_env;
 use crate::command::git::{GitRepo, GitWorkTree};
 use crate::registry_packages::{PackagesCollection, RegistryPackage};
 use crate::release_regex;
@@ -24,10 +24,53 @@ use cargo_metadata::{
 };
 use cargo_utils::get_manifest_metadata;
 use chrono::NaiveDate;
+use secrecy::SecretString;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use toml_edit::TableLike;
 use tracing::{debug, info, instrument, trace};
+
+struct ReconstructedWorkspaces<T> {
+    commit_indexes: BTreeMap<String, usize>,
+    resources: Vec<T>,
+}
+
+impl<T> Default for ReconstructedWorkspaces<T> {
+    fn default() -> Self {
+        Self {
+            commit_indexes: BTreeMap::new(),
+            resources: Vec::new(),
+        }
+    }
+}
+
+impl<T> ReconstructedWorkspaces<T> {
+    fn get(&self, commit: &str) -> Option<&T> {
+        self.commit_indexes
+            .get(commit)
+            .map(|index| &self.resources[*index])
+    }
+
+    fn try_insert_with<E>(
+        &mut self,
+        commit: String,
+        reconstruct: impl FnOnce() -> Result<T, E>,
+    ) -> Result<&T, E> {
+        if let Some(index) = self.commit_indexes.get(&commit) {
+            return Ok(&self.resources[*index]);
+        }
+
+        let resource = reconstruct()?;
+        let index = self.resources.len();
+        self.resources.push(resource);
+        self.commit_indexes.insert(commit, index);
+        Ok(&self.resources[index])
+    }
+
+    fn into_resources(self) -> Vec<T> {
+        self.resources
+    }
+}
 
 // Used to indicate that this is a dummy commit with no corresponding ID available.
 // It should be at least 7 characters long to avoid a panic in git-cliff
@@ -92,8 +135,8 @@ fn get_temp_worktree_and_repo(
     Ok((repo, worktree))
 }
 
-/// Process a single `git_only` package: find its release tag, checkout that commit,
-/// run `cargo package`, and return the package metadata.
+/// Process a single `git_only` package: find its release tag and commit, reconstruct
+/// the workspace if it hasn't already been reconstructed, and return the package metadata.
 ///
 /// Returns `None` if no release tag is found (package will be treated as initial release).
 #[instrument(skip_all, fields(package_name = %package.name))]
@@ -102,7 +145,8 @@ fn process_git_only_package(
     unreleased_project_repo: &mut GitRepo,
     input: &UpdateRequest,
     is_multi_package: bool,
-) -> anyhow::Result<Option<(RegistryPackage, GitWorkTree)>> {
+    reconstructed_workspaces: &mut ReconstructedWorkspaces<GitWorkTree>,
+) -> anyhow::Result<Option<RegistryPackage>> {
     // Get the release tag template, falling back to default based on project structure
     let template = input
         .get_package_tag_name(&package.name)
@@ -115,11 +159,7 @@ fn process_git_only_package(
         release_regex.to_string()
     );
 
-    // Get the temporary worktree and repo that we run cargo package in
-    let (mut repo, worktree) = get_temp_worktree_and_repo(unreleased_project_repo, &package.name)
-        .context("get worktree and repo for package")?;
-
-    let Some((release_tag, version)) = repo
+    let Some((release_tag, version)) = unreleased_project_repo
         .get_release_tag(&release_regex, &package.name)
         .context("get release tag")?
     else {
@@ -137,21 +177,34 @@ fn process_git_only_package(
     );
 
     // Get the commit associated with the release tag
-    let release_commit = repo
+    let release_commit = unreleased_project_repo
         .get_tag_commit(&release_tag)
         .context("get release tag commit")?;
 
-    // Checkout that commit in the worktree
-    repo.checkout_commit(&release_commit)
-        .context("checkout release commit for package")?;
+    let was_reconstructed = reconstructed_workspaces.get(&release_commit).is_some();
+    let worktree = reconstructed_workspaces.try_insert_with(release_commit.clone(), || {
+        let (mut repo, worktree) =
+            get_temp_worktree_and_repo(unreleased_project_repo, &package.name)
+                .context("get worktree and repo for package")?;
 
-    // Run cargo package so we have our finalized package.
-    // In git_only mode we always package the whole workspace to make sure
-    // local path dependencies are materialized as local tarballs.
-    run_cargo_package(&worktree).context("run cargo package")?;
+        repo.checkout_commit(&release_commit)
+            .context("checkout release commit for package")?;
 
-    // Get the package metadata
-    let single_package = get_cargo_package(&worktree, &package.name).with_context(|| {
+        // Package and verify the whole workspace so unpublished path dependencies are
+        // materialized in Cargo's temporary local registry.
+        run_cargo_package(&worktree).context("run cargo package")?;
+        Ok::<_, anyhow::Error>(worktree)
+    })?;
+    if was_reconstructed {
+        debug!(
+            "Reusing packaged workspace at commit {release_commit} for package {}",
+            package.name
+        );
+    }
+
+    // Metadata paths point into the cached worktree. Any error aborts collection and drops
+    // all reconstructed workspaces, so an unusable artifact cannot be reused.
+    let single_package = get_cargo_package(worktree, &package.name).with_context(|| {
         format!(
             "get cargo package {} from worktree at {:?}",
             package.name,
@@ -160,14 +213,22 @@ fn process_git_only_package(
     })?;
 
     let registry_package = RegistryPackage::new(single_package, Some(release_commit));
-    Ok(Some((registry_package, worktree)))
+    Ok(Some(registry_package))
 }
 
 /// Run cargo package within a worktree
 fn run_cargo_package(worktree: &GitWorkTree) -> anyhow::Result<()> {
     let worktree_path = to_utf8_path(worktree.path())?;
-    let output = run_cargo(worktree_path, &["package", "--allow-dirty", "--workspace"])
-        .context("run cargo package in worktree")?;
+    let target_dir = worktree_path.join("target");
+    let output = run_cargo_with_env(
+        worktree_path,
+        &["package", "--allow-dirty", "--workspace"],
+        &[(
+            "CARGO_TARGET_DIR".to_owned(),
+            SecretString::from(target_dir.to_string()),
+        )],
+    )
+    .context("run cargo package in worktree")?;
 
     if !output.status.success() {
         anyhow::bail!("cargo package failed: {:?}", output.stderr);
@@ -180,10 +241,12 @@ fn get_cargo_package(worktree: &GitWorkTree, package_name: &str) -> anyhow::Resu
     let worktree_path = to_utf8_path(worktree.path())?;
     let manifest_path = worktree_path.join("Cargo.toml");
 
-    // Use current_dir so that CARGO_TARGET_DIR resolves correctly relative to worktree
+    // Keep artifacts inside the worktree even if the invocation configured a shared target dir.
+    let target_dir = worktree_path.join("target");
     let mut command = cargo_utils::cargo_metadata_command();
     let rust_package = command
         .current_dir(worktree_path.as_std_path())
+        .env("CARGO_TARGET_DIR", target_dir)
         .no_deps()
         .manifest_path(&manifest_path)
         .exec()
@@ -312,7 +375,9 @@ fn collect_git_only_packages(
     // NOTE: We need to prevent the worktrees from being dropped because their Drop
     // implementation cleans up the worktrees.
     // See the note on the custom worktree Drop impl for more details.
-    let mut worktrees = Vec::new();
+    // All reconstruction inputs other than the resolved commit are fixed for this invocation:
+    // repository, manifest, Cargo configuration/environment, and package arguments.
+    let mut reconstructed_workspaces = ReconstructedWorkspaces::default();
 
     let mut unreleased_project_repo = GitRepo::open(
         input
@@ -322,18 +387,18 @@ fn collect_git_only_packages(
     .context("create unreleased repo for spinning worktrees")?;
 
     for package in git_only_packages {
-        if let Some((registry_package, worktree)) = process_git_only_package(
+        if let Some(registry_package) = process_git_only_package(
             package,
             &mut unreleased_project_repo,
             input,
             is_multi_package,
+            &mut reconstructed_workspaces,
         )? {
             all_packages.insert(registry_package.package.name.to_string(), registry_package);
-            worktrees.push(worktree);
         }
     }
 
-    Ok((all_packages, worktrees))
+    Ok((all_packages, reconstructed_workspaces.into_resources()))
 }
 
 /// Fetch packages from the registry and return their metadata.
@@ -512,4 +577,110 @@ fn canonicalized_path(dependency: &dyn TableLike, package_dir: &Utf8Path) -> Opt
         .get("path")
         .and_then(|i| i.as_str())
         .and_then(|relpath| dunce::canonicalize(package_dir.join(relpath)).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReconstructedWorkspaces;
+    use std::{cell::Cell, rc::Rc};
+
+    #[derive(Debug)]
+    struct TrackedResource {
+        id: usize,
+        drops: Rc<Cell<usize>>,
+    }
+
+    impl Drop for TrackedResource {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get() + 1);
+        }
+    }
+
+    #[test]
+    fn reconstructs_shared_commit_once() {
+        let reconstructions = Cell::new(0);
+        let drops = Rc::new(Cell::new(0));
+        let mut workspaces = ReconstructedWorkspaces::default();
+
+        let first_id = workspaces
+            .try_insert_with("shared-commit".to_owned(), || {
+                reconstructions.set(reconstructions.get() + 1);
+                Ok::<_, ()>(TrackedResource {
+                    id: 1,
+                    drops: Rc::clone(&drops),
+                })
+            })
+            .unwrap()
+            .id;
+        let second_id = workspaces
+            .try_insert_with("shared-commit".to_owned(), || {
+                reconstructions.set(reconstructions.get() + 1);
+                Ok::<_, ()>(TrackedResource {
+                    id: 2,
+                    drops: Rc::clone(&drops),
+                })
+            })
+            .unwrap()
+            .id;
+
+        assert_eq!(reconstructions.get(), 1);
+        assert_eq!(first_id, second_id);
+        drop(workspaces);
+        assert_eq!(drops.get(), 1);
+    }
+
+    #[test]
+    fn reconstructs_different_commits_separately() {
+        let reconstructions = Cell::new(0);
+        let drops = Rc::new(Cell::new(0));
+        let mut workspaces = ReconstructedWorkspaces::default();
+
+        for commit in ["first-commit", "second-commit"] {
+            workspaces
+                .try_insert_with(commit.to_owned(), || {
+                    reconstructions.set(reconstructions.get() + 1);
+                    Ok::<_, ()>(TrackedResource {
+                        id: reconstructions.get(),
+                        drops: Rc::clone(&drops),
+                    })
+                })
+                .unwrap();
+        }
+
+        assert_eq!(reconstructions.get(), 2);
+        drop(workspaces);
+        assert_eq!(drops.get(), 2);
+    }
+
+    #[test]
+    fn failed_reconstruction_is_cleaned_up_and_not_cached() {
+        let attempts = Cell::new(0);
+        let drops = Rc::new(Cell::new(0));
+        let mut workspaces = ReconstructedWorkspaces::default();
+
+        let result = workspaces.try_insert_with("commit".to_owned(), || {
+            attempts.set(attempts.get() + 1);
+            let _partial_resource = TrackedResource {
+                id: 1,
+                drops: Rc::clone(&drops),
+            };
+            Err::<TrackedResource, _>("reconstruction failed")
+        });
+
+        assert_eq!(result.unwrap_err(), "reconstruction failed");
+        assert_eq!(drops.get(), 1);
+        workspaces
+            .try_insert_with("commit".to_owned(), || {
+                attempts.set(attempts.get() + 1);
+                Ok::<_, &str>(TrackedResource {
+                    id: 2,
+                    drops: Rc::clone(&drops),
+                })
+            })
+            .unwrap();
+
+        assert_eq!(attempts.get(), 2);
+        drop(workspaces);
+        assert_eq!(drops.get(), 2);
+    }
 }

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -25,52 +25,10 @@ use cargo_metadata::{
 use cargo_utils::get_manifest_metadata;
 use chrono::NaiveDate;
 use secrecy::SecretString;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, btree_map::Entry};
 use std::path::PathBuf;
 use toml_edit::TableLike;
 use tracing::{debug, info, instrument, trace};
-
-struct ReconstructedWorkspaces<T> {
-    commit_indexes: BTreeMap<String, usize>,
-    resources: Vec<T>,
-}
-
-impl<T> Default for ReconstructedWorkspaces<T> {
-    fn default() -> Self {
-        Self {
-            commit_indexes: BTreeMap::new(),
-            resources: Vec::new(),
-        }
-    }
-}
-
-impl<T> ReconstructedWorkspaces<T> {
-    fn get(&self, commit: &str) -> Option<&T> {
-        self.commit_indexes
-            .get(commit)
-            .map(|index| &self.resources[*index])
-    }
-
-    fn try_insert_with<E>(
-        &mut self,
-        commit: String,
-        reconstruct: impl FnOnce() -> Result<T, E>,
-    ) -> Result<&T, E> {
-        if let Some(index) = self.commit_indexes.get(&commit) {
-            return Ok(&self.resources[*index]);
-        }
-
-        let resource = reconstruct()?;
-        let index = self.resources.len();
-        self.resources.push(resource);
-        self.commit_indexes.insert(commit, index);
-        Ok(&self.resources[index])
-    }
-
-    fn into_resources(self) -> Vec<T> {
-        self.resources
-    }
-}
 
 // Used to indicate that this is a dummy commit with no corresponding ID available.
 // It should be at least 7 characters long to avoid a panic in git-cliff
@@ -117,11 +75,6 @@ fn get_temp_worktree_and_repo(
     original_repo: &mut GitRepo,
     package_name: &str,
 ) -> anyhow::Result<(GitRepo, GitWorkTree)> {
-    // Clean up any existing worktree with this name
-    original_repo
-        .cleanup_worktree_if_exists(package_name)
-        .context("cleanup existing worktree")?;
-
     // make a worktree for the package
     let worktree = original_repo
         .temp_worktree(Some(package_name), package_name)
@@ -145,7 +98,7 @@ fn process_git_only_package(
     unreleased_project_repo: &mut GitRepo,
     input: &UpdateRequest,
     is_multi_package: bool,
-    reconstructed_workspaces: &mut ReconstructedWorkspaces<GitWorkTree>,
+    reconstructed_workspaces: &mut BTreeMap<String, GitWorkTree>,
 ) -> anyhow::Result<Option<RegistryPackage>> {
     // Get the release tag template, falling back to default based on project structure
     let template = input
@@ -181,26 +134,28 @@ fn process_git_only_package(
         .get_tag_commit(&release_tag)
         .context("get release tag commit")?;
 
-    let was_reconstructed = reconstructed_workspaces.get(&release_commit).is_some();
-    let worktree = reconstructed_workspaces.try_insert_with(release_commit.clone(), || {
-        let (mut repo, worktree) =
-            get_temp_worktree_and_repo(unreleased_project_repo, &package.name)
-                .context("get worktree and repo for package")?;
+    let worktree = match reconstructed_workspaces.entry(release_commit.clone()) {
+        Entry::Occupied(entry) => {
+            debug!(
+                "Reusing packaged workspace at commit {release_commit} for package {}",
+                package.name
+            );
+            entry.into_mut()
+        }
+        Entry::Vacant(entry) => {
+            let (mut repo, worktree) =
+                get_temp_worktree_and_repo(unreleased_project_repo, &package.name)
+                    .context("get worktree and repo for package")?;
 
-        repo.checkout_commit(&release_commit)
-            .context("checkout release commit for package")?;
+            repo.checkout_commit(&release_commit)
+                .context("checkout release commit for package")?;
 
-        // Package and verify the whole workspace so unpublished path dependencies are
-        // materialized in Cargo's temporary local registry.
-        run_cargo_package(&worktree).context("run cargo package")?;
-        Ok::<_, anyhow::Error>(worktree)
-    })?;
-    if was_reconstructed {
-        debug!(
-            "Reusing packaged workspace at commit {release_commit} for package {}",
-            package.name
-        );
-    }
+            // Package and verify the whole workspace so unpublished path dependencies are
+            // materialized in Cargo's temporary local registry.
+            run_cargo_package(&worktree).context("run cargo package")?;
+            entry.insert(worktree)
+        }
+    };
 
     // Metadata paths point into the cached worktree. Any error aborts collection and drops
     // all reconstructed workspaces, so an unusable artifact cannot be reused.
@@ -375,9 +330,9 @@ fn collect_git_only_packages(
     // NOTE: We need to prevent the worktrees from being dropped because their Drop
     // implementation cleans up the worktrees.
     // See the note on the custom worktree Drop impl for more details.
-    // All reconstruction inputs other than the resolved commit are fixed for this invocation:
-    // repository, manifest, Cargo configuration/environment, and package arguments.
-    let mut reconstructed_workspaces = ReconstructedWorkspaces::default();
+    // Packages released at the same commit share one reconstructed workspace: all other
+    // reconstruction inputs (repository, manifest, Cargo config) are fixed for this invocation.
+    let mut reconstructed_workspaces: BTreeMap<String, GitWorkTree> = BTreeMap::new();
 
     let mut unreleased_project_repo = GitRepo::open(
         input
@@ -398,7 +353,10 @@ fn collect_git_only_packages(
         }
     }
 
-    Ok((all_packages, reconstructed_workspaces.into_resources()))
+    Ok((
+        all_packages,
+        reconstructed_workspaces.into_values().collect(),
+    ))
 }
 
 /// Fetch packages from the registry and return their metadata.
@@ -581,106 +539,44 @@ fn canonicalized_path(dependency: &dyn TableLike, package_dir: &Utf8Path) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use super::ReconstructedWorkspaces;
-    use std::{cell::Cell, rc::Rc};
-
-    #[derive(Debug)]
-    struct TrackedResource {
-        id: usize,
-        drops: Rc<Cell<usize>>,
-    }
-
-    impl Drop for TrackedResource {
-        fn drop(&mut self) {
-            self.drops.set(self.drops.get() + 1);
-        }
-    }
-
     #[test]
-    fn reconstructs_shared_commit_once() {
-        let reconstructions = Cell::new(0);
-        let drops = Rc::new(Cell::new(0));
-        let mut workspaces = ReconstructedWorkspaces::default();
-
-        let first_id = workspaces
-            .try_insert_with("shared-commit".to_owned(), || {
-                reconstructions.set(reconstructions.get() + 1);
-                Ok::<_, ()>(TrackedResource {
-                    id: 1,
-                    drops: Rc::clone(&drops),
-                })
-            })
-            .unwrap()
-            .id;
-        let second_id = workspaces
-            .try_insert_with("shared-commit".to_owned(), || {
-                reconstructions.set(reconstructions.get() + 1);
-                Ok::<_, ()>(TrackedResource {
-                    id: 2,
-                    drops: Rc::clone(&drops),
-                })
-            })
-            .unwrap()
-            .id;
-
-        assert_eq!(reconstructions.get(), 1);
-        assert_eq!(first_id, second_id);
-        drop(workspaces);
-        assert_eq!(drops.get(), 1);
-    }
-
-    #[test]
-    fn reconstructs_different_commits_separately() {
-        let reconstructions = Cell::new(0);
-        let drops = Rc::new(Cell::new(0));
-        let mut workspaces = ReconstructedWorkspaces::default();
-
-        for commit in ["first-commit", "second-commit"] {
-            workspaces
-                .try_insert_with(commit.to_owned(), || {
-                    reconstructions.set(reconstructions.get() + 1);
-                    Ok::<_, ()>(TrackedResource {
-                        id: reconstructions.get(),
-                        drops: Rc::clone(&drops),
-                    })
-                })
-                .unwrap();
-        }
-
-        assert_eq!(reconstructions.get(), 2);
-        drop(workspaces);
-        assert_eq!(drops.get(), 2);
-    }
-
-    #[test]
-    fn failed_reconstruction_is_cleaned_up_and_not_cached() {
-        let attempts = Cell::new(0);
-        let drops = Rc::new(Cell::new(0));
-        let mut workspaces = ReconstructedWorkspaces::default();
-
-        let result = workspaces.try_insert_with("commit".to_owned(), || {
-            attempts.set(attempts.get() + 1);
-            let _partial_resource = TrackedResource {
-                id: 1,
-                drops: Rc::clone(&drops),
-            };
-            Err::<TrackedResource, _>("reconstruction failed")
-        });
-
-        assert_eq!(result.unwrap_err(), "reconstruction failed");
-        assert_eq!(drops.get(), 1);
-        workspaces
-            .try_insert_with("commit".to_owned(), || {
-                attempts.set(attempts.get() + 1);
-                Ok::<_, &str>(TrackedResource {
-                    id: 2,
-                    drops: Rc::clone(&drops),
-                })
-            })
+    fn reconstruction_preserves_existing_package_named_worktree() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(root.path().join("repo")).unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let signature = git2::Signature::now("test", "test@example.com").unwrap();
+        let initial_commit = repo
+            .commit(Some("HEAD"), &signature, &signature, "initial", &tree, &[])
             .unwrap();
+        let existing_path = root.path().join("mylib");
+        let existing = repo.worktree("mylib", &existing_path, None).unwrap();
+        let uncommitted_file = existing_path.join("notes.txt");
+        fs_err::write(&uncommitted_file, "work in progress").unwrap();
 
-        assert_eq!(attempts.get(), 2);
-        drop(workspaces);
-        assert_eq!(drops.get(), 2);
+        let mut original = super::GitRepo::open(repo.path()).unwrap();
+        let (temporary_repo, temporary) =
+            super::get_temp_worktree_and_repo(&mut original, "mylib").unwrap();
+        let temporary_path = temporary.path().to_path_buf();
+        assert_ne!(temporary_path, existing_path);
+        assert!(existing.validate().is_ok());
+
+        drop(temporary_repo);
+        drop(temporary);
+
+        assert!(!temporary_path.exists());
+        assert_eq!(repo.worktrees().unwrap().len(), 1);
+        assert!(existing.validate().is_ok());
+        assert_eq!(
+            fs_err::read_to_string(&uncommitted_file).unwrap(),
+            "work in progress"
+        );
+        assert_eq!(
+            repo.find_branch("mylib", git2::BranchType::Local)
+                .unwrap()
+                .get()
+                .target(),
+            Some(initial_commit)
+        );
     }
 }

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -541,6 +541,7 @@ fn canonicalized_path(dependency: &dyn TableLike, package_dir: &Utf8Path) -> Opt
 mod tests {
     #[test]
     fn reconstruction_preserves_existing_package_named_worktree() {
+        // Create an initial commit so the worktrees have a branch target.
         let root = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init(root.path().join("repo")).unwrap();
         let tree_id = repo.index().unwrap().write_tree().unwrap();
@@ -549,11 +550,14 @@ mod tests {
         let initial_commit = repo
             .commit(Some("HEAD"), &signature, &signature, "initial", &tree, &[])
             .unwrap();
+
+        // Simulate a user's worktree named after the package, with uncommitted work.
         let existing_path = root.path().join("mylib");
         let existing = repo.worktree("mylib", &existing_path, None).unwrap();
         let uncommitted_file = existing_path.join("notes.txt");
         fs_err::write(&uncommitted_file, "work in progress").unwrap();
 
+        // Reconstruction must create a separate worktree despite the name collision.
         let mut original = super::GitRepo::open(repo.path()).unwrap();
         let (temporary_repo, temporary) =
             super::get_temp_worktree_and_repo(&mut original, "mylib").unwrap();
@@ -561,11 +565,14 @@ mod tests {
         assert_ne!(temporary_path, existing_path);
         assert!(existing.validate().is_ok());
 
+        // Dropping the temporary worktree must clean up only its own resources.
         drop(temporary_repo);
         drop(temporary);
 
         assert!(!temporary_path.exists());
         assert_eq!(repo.worktrees().unwrap().len(), 1);
+
+        // The user's worktree, uncommitted file, and branch target must remain intact.
         assert!(existing.validate().is_ok());
         assert_eq!(
             fs_err::read_to_string(&uncommitted_file).unwrap(),


### PR DESCRIPTION
## Why

In git-only Cargo workspaces, `release-plz update` reconstructs and verifies the complete historical workspace _once per analyzed package_. Workspaces with unpublished internal path dependencies therefore repeated the same multi-minute `cargo package --workspace` operation for every package sharing a release tag. 
In a medium-sized workspace (~15 packages), it takes 1h17m for `release-plz update` to complete 😅 ([logs](https://github.com/Firma-AI/openfirma/actions/runs/30535687649/job/90848328510)).

## What changed

For each unique commit SHA, we rebuild the workspace _but we keep it around_ until command execution completes. 
If two packages from the same workspace have to be packaged for the same unique commit SHA, we reuse the "hydrated" workspace from the previous package, thus getting a warm cache.

The regression fixture has one binary and two unpublished internal libraries at one commit. Historical workspace packaging drops from three operations to one.