### PR TITLE
Skip `cargo package --list` when Cargo.toml.orig is present

### DIFF
--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -772,7 +772,12 @@ async fn release_plz_detects_cargo_lock_updates_from_registry() {
         .success();
     context.push_all_changes("chore: update Cargo.lock");
 
-    context.run_release_pr().success();
+    let debug_outcome = context.run_release_pr();
+    eprintln!(
+        "DEBUG2130 STDERR:\n{}",
+        String::from_utf8_lossy(&debug_outcome.get_output().stderr)
+    );
+    debug_outcome.success();
     let today = today();
 
     let opened_prs = context.opened_release_prs().await;

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -772,12 +772,7 @@ async fn release_plz_detects_cargo_lock_updates_from_registry() {
         .success();
     context.push_all_changes("chore: update Cargo.lock");
 
-    let debug_outcome = context.run_release_pr();
-    eprintln!(
-        "DEBUG2130 STDERR:\n{}",
-        String::from_utf8_lossy(&debug_outcome.get_output().stderr)
-    );
-    debug_outcome.success();
+    context.run_release_pr().success();
     let today = today();
 
     let opened_prs = context.opened_release_prs().await;

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -304,10 +304,7 @@ mod tests {
 
         assert_eq!(
             files,
-            vec![
-                Utf8PathBuf::from("Cargo.toml.orig"),
-                Utf8PathBuf::from("src/lib.rs"),
-            ]
+            vec![Utf8PathBuf::from("Cargo.toml.orig"), Utf8PathBuf::from("src/lib.rs")]
         );
     }
 

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -211,7 +211,9 @@ pub fn is_readme_updated(
         Some(local_package_readme_path) => {
             let registry_package_readme_path = registry_package_path.join("README.md");
             if !registry_package_readme_path.exists() {
-                eprintln!("DEBUG2130: registry readme missing at {registry_package_readme_path:?}, returning true");
+                eprintln!(
+                    "DEBUG2130: registry readme missing at {registry_package_readme_path:?}, returning true"
+                );
                 return Ok(true);
             }
             match are_files_equal(&local_package_readme_path, &registry_package_readme_path) {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -364,7 +364,8 @@ mod tests {
         // registry extraction, with content that would trip up the comparison
         // if it weren't filtered out.
         fs::create_dir_all(package.join(".git/objects")).expect("cannot create .git dir");
-        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main").expect("cannot write .git/HEAD");
+        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main")
+            .expect("cannot write .git/HEAD");
         fs::write(
             package.join(".git/objects/pack-dummy"),
             "binary-ish content",

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -206,10 +206,12 @@ pub fn is_readme_updated(
     };
 
     let local_package_readme_path = local_readme_override(&package, local_package_path);
+    eprintln!("DEBUG2130: local_package_readme_path={local_package_readme_path:?}");
     let are_readmes_equal = match local_package_readme_path? {
         Some(local_package_readme_path) => {
             let registry_package_readme_path = registry_package_path.join("README.md");
             if !registry_package_readme_path.exists() {
+                eprintln!("DEBUG2130: registry readme missing at {registry_package_readme_path:?}, returning true");
                 return Ok(true);
             }
             match are_files_equal(&local_package_readme_path, &registry_package_readme_path) {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -27,7 +27,7 @@ pub fn are_packages_equal(
         local_package, registry_package
     );
     if !are_cargo_toml_equal(local_package, registry_package) {
-        debug!("Cargo.toml is different");
+        eprintln!("DEBUG2130: Cargo.toml is different");
         return Ok(false);
     }
 
@@ -65,7 +65,10 @@ pub fn are_packages_equal(
 
     if !local_files.clone().eq(registry_files) {
         // New files were added or removed.
-        debug!("cargo package list is different");
+        eprintln!(
+            "DEBUG2130: file list differs. local={:?} registry={:?}",
+            local_package_files, registry_package_files
+        );
         return Ok(false);
     }
 
@@ -91,6 +94,7 @@ pub fn are_packages_equal(
 
         let registry_path = registry_package.join(relative_path);
         if !are_files_equal(&local_path, &registry_path).context("files are not equal")? {
+            eprintln!("DEBUG2130: file content differs for {relative_path:?}");
             return Ok(false);
         }
     }

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -281,7 +281,7 @@ mod tests {
     /// should use the fast, disk-listing path when `Cargo.toml.orig` is
     /// present, instead of shelling out to `cargo package --list`.
     /// Regression test for
-    /// https://github.com/release-plz/release-plz/issues/2130
+    /// <https://github.com/release-plz/release-plz/issues/2130>
     #[test]
     fn get_cargo_package_files_uses_disk_listing_when_cargo_toml_orig_present() {
         let dir = tempfile::tempdir().expect("cannot create tempdir");

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -27,7 +27,6 @@ pub fn are_packages_equal(
         local_package, registry_package
     );
     if !are_cargo_toml_equal(local_package, registry_package) {
-        eprintln!("DEBUG2130: Cargo.toml is different");
         return Ok(false);
     }
 
@@ -65,9 +64,6 @@ pub fn are_packages_equal(
 
     if !local_files.clone().eq(registry_files) {
         // New files were added or removed.
-        eprintln!(
-            "DEBUG2130: file list differs. local={local_package_files:?} registry={registry_package_files:?}"
-        );
         return Ok(false);
     }
 
@@ -93,7 +89,6 @@ pub fn are_packages_equal(
 
         let registry_path = registry_package.join(relative_path);
         if !are_files_equal(&local_path, &registry_path).context("files are not equal")? {
-            eprintln!("DEBUG2130: file content differs for {relative_path:?}");
             return Ok(false);
         }
     }
@@ -159,6 +154,14 @@ fn list_packaged_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {
                 .with_context(|| format!("cannot read file type for {path:?}"))?;
 
             if file_type.is_dir() {
+                // Registry sources extracted via `git clone` (as some registries do) leave
+                // a full `.git` directory behind. `cargo package --list` never includes
+                // `.git`, so the disk-listing fast path must skip it too, or every file
+                // inside it would make the registry package look different from the
+                // local one for reasons unrelated to the actual packaged contents.
+                if path.file_name() == Some(".git") {
+                    continue;
+                }
                 dirs.push(path);
             } else {
                 let rel_path = path
@@ -206,14 +209,10 @@ pub fn is_readme_updated(
     };
 
     let local_package_readme_path = local_readme_override(&package, local_package_path);
-    eprintln!("DEBUG2130: local_package_readme_path={local_package_readme_path:?}");
     let are_readmes_equal = match local_package_readme_path? {
         Some(local_package_readme_path) => {
             let registry_package_readme_path = registry_package_path.join("README.md");
             if !registry_package_readme_path.exists() {
-                eprintln!(
-                    "DEBUG2130: registry readme missing at {registry_package_readme_path:?}, returning true"
-                );
                 return Ok(true);
             }
             match are_files_equal(&local_package_readme_path, &registry_package_readme_path) {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -339,4 +339,45 @@ mod tests {
         let files = get_cargo_package_files(package).expect("should use disk listing");
         assert_eq!(files, vec![Utf8PathBuf::from("Cargo.toml.orig.orig")]);
     }
+
+    /// Some registries (e.g. this environment's Gitea cargo registry) extract
+    /// packages via `git clone`, leaving a full `.git` directory inside the
+    /// extracted package. `cargo package --list` always ignores `.git`, so the
+    /// disk-listing fast path must ignore it too, or every file inside it would
+    /// make a registry-extracted package look different from the local one for
+    /// reasons unrelated to the actual packaged contents.
+    /// Regression test for <https://github.com/release-plz/release-plz/issues/2130>.
+    #[test]
+    fn get_cargo_package_files_ignores_nested_git_dir() {
+        let dir = tempfile::tempdir().expect("cannot create tempdir");
+        let package = Utf8Path::from_path(dir.path()).expect("non-utf8 tempdir path");
+
+        fs::write(
+            package.join("Cargo.toml.orig"),
+            "this is not a real manifest",
+        )
+        .expect("cannot write Cargo.toml.orig");
+        fs::create_dir(package.join("src")).expect("cannot create src dir");
+        fs::write(package.join("src/lib.rs"), "").expect("cannot write lib.rs");
+
+        // Simulate a nested `.git` directory left behind by a git-clone-based
+        // registry extraction, with content that would trip up the comparison
+        // if it weren't filtered out.
+        fs::create_dir_all(package.join(".git/objects")).expect("cannot create .git dir");
+        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main")
+            .expect("cannot write .git/HEAD");
+        fs::write(package.join(".git/objects/pack-dummy"), "binary-ish content")
+            .expect("cannot write .git/objects/pack-dummy");
+
+        let mut files = get_cargo_package_files(package).expect("should use disk listing");
+        files.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        assert_eq!(
+            files,
+            vec![
+                Utf8PathBuf::from("Cargo.toml.orig"),
+                Utf8PathBuf::from("src/lib.rs")
+            ]
+        );
+    }
 }

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -66,8 +66,7 @@ pub fn are_packages_equal(
     if !local_files.clone().eq(registry_files) {
         // New files were added or removed.
         eprintln!(
-            "DEBUG2130: file list differs. local={:?} registry={:?}",
-            local_package_files, registry_package_files
+            "DEBUG2130: file list differs. local={local_package_files:?} registry={registry_package_files:?}"
         );
         return Ok(false);
     }

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -51,14 +51,15 @@ pub fn are_packages_equal(
         registry_package.join("Cargo.toml.orig"),
     )?;
 
-    let local_files = local_package_files
-        .iter()
-        .filter(|file| *file != "Cargo.toml.orig" && *file != ".cargo_vcs_info.json");
+    let local_files = local_package_files.iter().filter(|file| {
+        *file != "Cargo.toml.orig" && *file != ".cargo_vcs_info.json" && *file != "Cargo.lock"
+    });
 
     let registry_files = registry_package_files.iter().filter(|file| {
         *file != "Cargo.toml.orig"
             && *file != "Cargo.toml.orig.orig"
             && *file != ".cargo_vcs_info.json"
+            && *file != "Cargo.lock"
     });
 
     if !local_files.clone().eq(registry_files) {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -364,10 +364,12 @@ mod tests {
         // registry extraction, with content that would trip up the comparison
         // if it weren't filtered out.
         fs::create_dir_all(package.join(".git/objects")).expect("cannot create .git dir");
-        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main")
-            .expect("cannot write .git/HEAD");
-        fs::write(package.join(".git/objects/pack-dummy"), "binary-ish content")
-            .expect("cannot write .git/objects/pack-dummy");
+        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main").expect("cannot write .git/HEAD");
+        fs::write(
+            package.join(".git/objects/pack-dummy"),
+            "binary-ish content",
+        )
+        .expect("cannot write .git/objects/pack-dummy");
 
         let mut files = get_cargo_package_files(package).expect("should use disk listing");
         files.sort_by(|a, b| a.as_str().cmp(b.as_str()));

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -363,14 +363,12 @@ mod tests {
         // Simulate a nested `.git` directory left behind by a git-clone-based
         // registry extraction, with content that would trip up the comparison
         // if it weren't filtered out.
-        fs::create_dir_all(package.join(".git/objects")).expect("cannot create .git dir");
-        fs::write(package.join(".git/HEAD"), "ref: refs/heads/main")
-            .expect("cannot write .git/HEAD");
-        fs::write(
-            package.join(".git/objects/pack-dummy"),
-            "binary-ish content",
-        )
-        .expect("cannot write .git/objects/pack-dummy");
+        let git_objects = package.join(".git/objects");
+        let git_head = package.join(".git/HEAD");
+        let pack_file = package.join(".git/objects/pack-dummy");
+        fs::create_dir_all(&git_objects).expect("cannot create .git dir");
+        fs::write(&git_head, "ref: refs/heads/main").expect("cannot write .git/HEAD");
+        fs::write(&pack_file, "binary-ish content").expect("cannot write pack file");
 
         let mut files = get_cargo_package_files(package).expect("should use disk listing");
         files.sort_by(|a, b| a.as_str().cmp(b.as_str()));

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -103,16 +103,16 @@ fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> anyhow::Result<()> {
 }
 
 pub fn get_cargo_package_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {
-    // If this crate was packaged locally (i.e. is inside target/package), we can list files
-    // directly from disk without invoking `cargo package`.
-    // At the moment, this only happens in the git_only flow.
-    // TODO: Do this always, not only if we are in target/package.
-    //       See https://github.com/release-plz/release-plz/issues/2130
+    // If Cargo.toml.orig (or its renamed variant Cargo.toml.orig.orig -- see
+    // `are_packages_equal`) is present, this package's on-disk contents already
+    // reflect exactly what `cargo package` would produce. This is true both for
+    // packages extracted from a registry, and for ones built locally via
+    // `cargo package` (e.g. in the git_only flow). In that case we can list files
+    // directly from disk instead of invoking `cargo package`, which is slower and
+    // can fail if the directory doesn't have full cargo metadata set up.
+    // See https://github.com/release-plz/release-plz/issues/2130
     info!("Getting packaged files for crate at {}", package);
-    if is_cargo_packaged_dir(package)
-        && (package.join("Cargo.toml.orig").exists()
-            || package.join("Cargo.toml.orig.orig").exists())
-    {
+    if package.join("Cargo.toml.orig").exists() || package.join("Cargo.toml.orig.orig").exists() {
         let list =
             list_packaged_files(package).context("cannot list packaged files from directory")?;
         debug!("Packaged files: {:?}", list);
@@ -138,13 +138,6 @@ fn get_cargo_package_list(package: &Utf8Path) -> Result<Vec<Utf8PathBuf>, anyhow
 
     let files = output.stdout.lines().map(Utf8PathBuf::from).collect();
     Ok(files)
-}
-
-fn is_cargo_packaged_dir(package: &Utf8Path) -> bool {
-    package.ancestors().any(|ancestor| {
-        ancestor.file_name() == Some("package")
-            && ancestor.parent().and_then(|parent| parent.file_name()) == Some("target")
-    })
 }
 
 fn list_packaged_files(package: &Utf8Path) -> anyhow::Result<Vec<Utf8PathBuf>> {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -271,3 +271,61 @@ fn read_package_metadata(
         .context("cannot find package in Cargo.toml")?;
     Ok(package)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Registry-extracted packages (which don't live under `target/package`)
+    /// should use the fast, disk-listing path when `Cargo.toml.orig` is
+    /// present, instead of shelling out to `cargo package --list`.
+    /// Regression test for
+    /// https://github.com/release-plz/release-plz/issues/2130
+    #[test]
+    fn get_cargo_package_files_uses_disk_listing_when_cargo_toml_orig_present() {
+        let dir = tempfile::tempdir().expect("cannot create tempdir");
+        let package = Utf8Path::from_path(dir.path()).expect("non-utf8 tempdir path");
+
+        // Deliberately do NOT write a valid Cargo.toml manifest. If
+        // `get_cargo_package_files` fell through to invoking
+        // `cargo package --list`, it would fail here since there's no valid
+        // cargo manifest in this directory. The fact that it succeeds and
+        // returns exactly the files we wrote proves the disk-listing fast
+        // path was taken -- without this needing to be a real cargo project
+        // or to live under target/package.
+        fs::write(package.join("Cargo.toml.orig"), "this is not a real manifest")
+            .expect("cannot write Cargo.toml.orig");
+        fs::create_dir(package.join("src")).expect("cannot create src dir");
+        fs::write(package.join("src/lib.rs"), "").expect("cannot write lib.rs");
+
+        let mut files = get_cargo_package_files(package).expect("should use disk listing");
+        files.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        assert_eq!(
+            files,
+            vec![
+                Utf8PathBuf::from("Cargo.toml.orig"),
+                Utf8PathBuf::from("src/lib.rs"),
+            ]
+        );
+    }
+
+    /// Same as above, but for the `Cargo.toml.orig.orig` marker used while
+    /// `are_packages_equal` has temporarily renamed the registry package's
+    /// `Cargo.toml.orig` out of the way.
+    #[test]
+    fn get_cargo_package_files_uses_disk_listing_when_cargo_toml_orig_orig_present() {
+        let dir = tempfile::tempdir().expect("cannot create tempdir");
+        let package = Utf8Path::from_path(dir.path()).expect("non-utf8 tempdir path");
+
+        fs::write(
+            package.join("Cargo.toml.orig.orig"),
+            "this is not a real manifest",
+        )
+        .expect("cannot write Cargo.toml.orig.orig");
+
+        let files = get_cargo_package_files(package).expect("should use disk listing");
+        assert_eq!(files, vec![Utf8PathBuf::from("Cargo.toml.orig.orig")]);
+    }
+}

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -60,6 +60,7 @@ pub fn are_packages_equal(
             && *file != "Cargo.toml.orig.orig"
             && *file != ".cargo_vcs_info.json"
             && *file != "Cargo.lock"
+            && *file != ".cargo-ok"
     });
 
     if !local_files.clone().eq(registry_files) {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -294,8 +294,11 @@ mod tests {
         // returns exactly the files we wrote proves the disk-listing fast
         // path was taken -- without this needing to be a real cargo project
         // or to live under target/package.
-        fs::write(package.join("Cargo.toml.orig"), "this is not a real manifest")
-            .expect("cannot write Cargo.toml.orig");
+        fs::write(
+            package.join("Cargo.toml.orig"),
+            "this is not a real manifest",
+        )
+        .expect("cannot write Cargo.toml.orig");
         fs::create_dir(package.join("src")).expect("cannot create src dir");
         fs::write(package.join("src/lib.rs"), "").expect("cannot write lib.rs");
 
@@ -304,7 +307,10 @@ mod tests {
 
         assert_eq!(
             files,
-            vec![Utf8PathBuf::from("Cargo.toml.orig"), Utf8PathBuf::from("src/lib.rs")]
+            vec![
+                Utf8PathBuf::from("Cargo.toml.orig"),
+                Utf8PathBuf::from("src/lib.rs")
+            ]
         );
     }
 


### PR DESCRIPTION
Fixes #2130

## Problem

`get_cargo_package_files` in `crates/release_plz_core/src/package_compare.rs` only took the fast disk-listing path (skipping `cargo package --list`) when **both** `is_cargo_packaged_dir(package)` was true **and** `Cargo.toml.orig`/`.orig.orig` existed. For registry-extracted packages that don't live under `target/package`, this meant `cargo package --list` was invoked even though the on-disk contents already reflect exactly what `cargo package` would produce, which is redundant and slower, and can fail if the directory doesn't have full cargo metadata set up.

## Fix

- Drop the `is_cargo_packaged_dir` requirement: now the disk-listing fast path is taken whenever `Cargo.toml.orig` or `Cargo.toml.orig.orig` exists, regardless of directory layout. The existing `#1144` edge case (registry crate missing `Cargo.toml.orig`) is still handled correctly, since `.exists()` just returns `false` and falls through to the `cargo package --list` path.
- While testing this against a Gitea-backed registry (used in this repo's own Docker integration tests), found and fixed two related correctness gaps in the disk-listing path that the previous `cargo package --list`-only path never hit:
  - `list_packaged_files` now skips nested `.git` directories entirely. Registries that extract packages via `git clone` leave a full `.git/` dir behind; `cargo package --list` always ignores `.git`, so the disk-listing fast path needs to as well, or every file inside it makes a registry-extracted package look different from the local one for reasons unrelated to the actual packaged contents.
  - `.cargo-ok` (a marker file cargo writes on successful extraction) and `Cargo.lock` are now excluded from the registry-side / both-sides file-list comparison respectively, since neither is part of what `cargo package --list` reports for the local side and `Cargo.lock` legitimately differs between a local workspace and a published lockfile.
- Added regression tests for the disk-listing fast path (`Cargo.toml.orig` present, `Cargo.toml.orig.orig` present, and nested `.git` directories being ignored).

## Testing

- Added unit tests in `package_compare.rs` covering the three scenarios above.
- Ran the full Docker-backed integration test suite locally/in CI on this branch, including `release_plz_detects_cargo_lock_updates_from_registry`, which exercises the registry round-trip end-to-end.
- `cargo clippy --all-targets --all-features --workspace` and `cargo fmt --all -- --check` both pass.

- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

I used an AI coding assistant (Claude) to help implement this fix and iterate on it against this repo's own Docker-backed integration tests. I reviewed the diagnosis, the resulting code changes, and the test suite myself, and I understand and can explain the root cause (the interaction between the `is_cargo_packaged_dir` check, `cargo package --list`'s implicit `.git` exclusion, and how registries that extract via `git clone` leave `.git/` behind) and the fix.