### PR TITLE
fix(core): fetch missing shallow history on demand

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -207,13 +207,17 @@ impl Repo {
             .context("failed to get message of last commit")
     }
 
-    fn previous_commit_at_paths(&self, paths: &[&Path]) -> anyhow::Result<String> {
-        self.nth_commit_at_paths(2, paths)
+    /// Return the previous commit touching these paths, or `None` at the end
+    /// of the available history. Git failures are returned separately.
+    pub fn previous_commit_at_paths(&self, paths: &[&Path]) -> anyhow::Result<Option<String>> {
+        self.nth_commit_at_paths_optional(2, paths)
             .context("failed to get message of previous commit")
     }
 
     pub fn checkout_previous_commit_at_paths(&self, paths: &[&Path]) -> anyhow::Result<()> {
-        let commit = self.previous_commit_at_paths(paths)?;
+        let commit = self
+            .previous_commit_at_paths(paths)?
+            .context("not enough commits")?;
         self.checkout(&commit)?;
         Ok(())
     }
@@ -249,6 +253,15 @@ impl Repo {
         )
     )]
     fn nth_commit_at_paths(&self, nth: usize, paths: &[&Path]) -> anyhow::Result<String> {
+        self.nth_commit_at_paths_optional(nth, paths)?
+            .context("not enough commits")
+    }
+
+    fn nth_commit_at_paths_optional(
+        &self,
+        nth: usize,
+        paths: &[&Path],
+    ) -> anyhow::Result<Option<String>> {
         let nth_str = nth.to_string();
 
         let git_args = {
@@ -262,11 +275,13 @@ impl Repo {
 
         let commit_list = self.git(&git_args)?;
         let mut commits = commit_list.lines();
-        let last_commit = commits.nth(nth - 1).context("not enough commits")?;
+        let Some(last_commit) = commits.nth(nth - 1) else {
+            return Ok(None);
+        };
 
         Span::current().record("nth_commit", last_commit);
         debug!("nth_commit found");
-        Ok(last_commit.to_string())
+        Ok(Some(last_commit.to_string()))
     }
 
     pub fn current_commit_message(&self) -> anyhow::Result<String> {

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -28,7 +28,9 @@ use crate::{
     changelog_parser,
     command::update::changelog_update::OldChangelogs,
     diff::{Commit, Diff},
-    fs_utils, lock_compare,
+    fs_utils,
+    git_history::ShallowHistory,
+    lock_compare,
     registry_packages::{PackagesCollection, RegistryPackage},
     semver_check::{self, SemverCheck},
     toml_compare,
@@ -574,6 +576,27 @@ impl Updater<'_> {
         registry_packages: &PackagesCollection,
         repository: &Repo,
     ) -> anyhow::Result<Diff> {
+        loop {
+            repository.checkout_head()?;
+            let history = ShallowHistory::new(repository)?;
+            if let Some(diff) =
+                self.get_diff_with_history(package, registry_packages, repository, &history)?
+            {
+                return Ok(diff);
+            }
+            history.deepen(repository)?;
+            // Deepening changes path-filtered history, including which commit
+            // last touched the package. Discard the partial result and restart.
+        }
+    }
+
+    fn get_diff_with_history(
+        &self,
+        package: &Package,
+        registry_packages: &PackagesCollection,
+        repository: &Repo,
+        history: &ShallowHistory,
+    ) -> anyhow::Result<Option<Diff>> {
         info!(
             "determining next version for {} {}",
             package.name, package.version
@@ -585,7 +608,6 @@ impl Updater<'_> {
             .checkout_head()
             .context("can't checkout head to calculate diff")?;
         let registry_package = registry_packages.get_registry_package(&package.name);
-        let mut diff = Diff::new(registry_package.is_some());
         let pathbufs_to_check = pathbufs_to_check(&package_path, package)?;
         let paths_to_check: Vec<&Path> = pathbufs_to_check.iter().map(|p| p.as_ref()).collect();
         repository
@@ -624,13 +646,13 @@ impl Updater<'_> {
                 );
             }
         }
-        self.get_package_diff(
+        let diff = self.get_package_diff(
             &package_path,
             package,
             registry_package,
             repository,
             tag_commit.as_deref(),
-            &mut diff,
+            history,
         )?;
 
         repository
@@ -646,8 +668,9 @@ impl Updater<'_> {
         registry_package: Option<&RegistryPackage>,
         repository: &Repo,
         tag_commit: Option<&str>,
-        diff: &mut Diff,
-    ) -> anyhow::Result<()> {
+        history: &ShallowHistory,
+    ) -> anyhow::Result<Option<Diff>> {
+        let mut diff = Diff::new(registry_package.is_some());
         let pathbufs_to_check = pathbufs_to_check(package_path, package)?;
         let paths_to_check: Vec<&Path> = pathbufs_to_check.iter().map(|p| p.as_ref()).collect();
         let max_analyze_commits = if registry_package.is_none() {
@@ -659,7 +682,7 @@ impl Updater<'_> {
             u32::MAX
         };
 
-        for _ in 0..max_analyze_commits {
+        for analyzed in 0..max_analyze_commits {
             let current_commit_message = repository.current_commit_message()?;
             let current_commit_hash = repository.current_commit_hash()?;
 
@@ -699,7 +722,7 @@ impl Updater<'_> {
                         // workspace might have changed.
                         // If the dependencies changed, we add a commit to the diff.
                         self.add_dependencies_update_if_any(
-                            diff,
+                            &mut diff,
                             &registry_package.package,
                             package,
                             registry_package_path,
@@ -709,7 +732,23 @@ impl Updater<'_> {
                     // the package was published at this commit, so we will not count this commit
                     // as part of the release.
                     // We can process the next package.
-                    break;
+                    if history.is_complete_since(repository, &[&current_commit_hash])? {
+                        return Ok(Some(diff));
+                    }
+                    // A release can also include ancestry from merged branches
+                    // that is not reachable from this package's last changed commit.
+                    let mut baselines = vec![current_commit_hash.as_str()];
+                    for baseline in [tag_commit, registry_package.published_at_sha1()]
+                        .into_iter()
+                        .flatten()
+                    {
+                        if repository.is_ancestor(&current_commit_hash, baseline) {
+                            baselines.push(baseline);
+                        }
+                    }
+                    return Ok(history
+                        .is_complete_since(repository, &baselines)?
+                        .then_some(diff));
                 } else {
                     // When version is already bumped, we still collect commits to update the changelog,
                     // but mark that version should not be bumped further.
@@ -722,31 +761,47 @@ impl Updater<'_> {
                         );
                         diff.set_version_unpublished(registry_package.package.version.clone());
                     }
+                    if history.contains(&current_commit_hash) {
+                        return Ok(None);
+                    }
                     if are_changed_files_in_pkg()? {
                         debug!("packages contain different files");
                         // At this point of the git history, the two packages are different,
                         // which means that this commit is not present in the published package.
                         diff.commits.push(Commit::new(
-                            current_commit_hash,
+                            current_commit_hash.clone(),
                             current_commit_message.clone(),
                         ));
                     }
                 }
-            } else if are_changed_files_in_pkg()? {
-                diff.commits.push(Commit::new(
-                    current_commit_hash,
-                    current_commit_message.clone(),
-                ));
+            } else {
+                if history.contains(&current_commit_hash) {
+                    return Ok(None);
+                }
+                if are_changed_files_in_pkg()? {
+                    diff.commits.push(Commit::new(
+                        current_commit_hash.clone(),
+                        current_commit_message.clone(),
+                    ));
+                }
+            }
+            if analyzed + 1 == max_analyze_commits {
+                // Honor the intentional limit for first releases without
+                // fetching ancestry older than the last requested commit.
+                return Ok(history
+                    .is_complete_since(repository, &[&current_commit_hash])?
+                    .then_some(diff));
             }
             // Go back to the previous commit.
             // Keep in mind that the info contained in `package` might be outdated,
             // because commits could contain changes to Cargo.toml.
-            if let Err(_err) = repository.checkout_previous_commit_at_paths(&paths_to_check) {
+            let Some(previous) = repository.previous_commit_at_paths(&paths_to_check)? else {
                 debug!("there are no other commits");
-                break;
-            }
+                return Ok(history.is_complete_since(repository, &[])?.then_some(diff));
+            };
+            repository.checkout(&previous)?;
         }
-        Ok(())
+        Ok(Some(diff))
     }
 
     fn check_package_equality(

--- a/crates/release_plz_core/src/git_history.rs
+++ b/crates/release_plz_core/src/git_history.rs
@@ -1,0 +1,214 @@
+use std::collections::HashSet;
+
+use anyhow::Context as _;
+use git_cmd::Repo;
+use tracing::info;
+
+/// Shallow roots reachable from the commit being analyzed. Path-filtered Git logs
+/// can hide roots on merged branches, so inspect the entire ancestry here.
+pub(crate) struct ShallowHistory {
+    head: String,
+    boundaries: HashSet<String>,
+}
+
+impl ShallowHistory {
+    pub(crate) fn new(repo: &Repo) -> anyhow::Result<Self> {
+        let head = repo.current_commit_hash()?;
+        Self::at_head(repo, head)
+    }
+
+    fn at_head(repo: &Repo, head: String) -> anyhow::Result<Self> {
+        let path = repo.git(&["rev-parse", "--git-path", "shallow"])?;
+        let path = repo.directory().join(path);
+        let shallow = match fs_err::read_to_string(path) {
+            Ok(shallow) => shallow,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(error) => return Err(error.into()),
+        };
+        let mut boundaries: HashSet<String> = shallow.lines().map(str::to_owned).collect();
+        if !boundaries.is_empty() {
+            let roots = repo.git(&["rev-list", "--max-parents=0", &head])?;
+            let roots: HashSet<&str> = roots.lines().collect();
+            boundaries.retain(|commit| roots.contains(commit.as_str()));
+        }
+        Ok(Self { head, boundaries })
+    }
+
+    pub(crate) fn contains(&self, commit: &str) -> bool {
+        self.boundaries.contains(commit)
+    }
+
+    /// A baseline excludes its ancestors, but not missing history on another
+    /// branch merged after the baseline.
+    pub(crate) fn is_complete_since(
+        &self,
+        repo: &Repo,
+        baselines: &[&str],
+    ) -> anyhow::Result<bool> {
+        if self.boundaries.is_empty() {
+            return Ok(true);
+        }
+        if baselines.is_empty() {
+            return Ok(false);
+        }
+        let mut args = vec!["rev-list", &self.head, "--not"];
+        args.extend_from_slice(baselines);
+        let commits = repo.git(&args)?;
+        Ok(!commits.lines().any(|commit| self.contains(commit)))
+    }
+
+    /// Fetch from the configured upstream without moving the branch being
+    /// analyzed. Batching avoids a network round trip for every missing parent.
+    pub(crate) fn deepen(&self, repo: &Repo) -> anyhow::Result<()> {
+        let remote = repo.original_remote();
+        let help = "More git history is needed to determine changes. Run `git fetch --unshallow` or set `fetch-depth: 0` in actions/checkout.";
+        info!("Fetching more git history from {remote} to determine changes");
+        repo.git(&[
+            "fetch",
+            "--deepen=50",
+            "--no-tags",
+            "--no-recurse-submodules",
+            remote,
+            &self.head,
+        ])
+        .with_context(|| format!("Failed to deepen the shallow repository. {help}"))?;
+        // The remote itself may be shallow. A successful fetch does not imply
+        // that it supplied any of the missing ancestry.
+        let after = Self::at_head(repo, self.head.clone())?;
+        anyhow::ensure!(
+            after.boundaries != self.boundaries,
+            "Fetching did not provide the missing git history. {help}"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cargo_metadata::camino::Utf8Path;
+    use git_cmd::git_in_dir;
+
+    use super::*;
+
+    fn clone_shallow(source: &Utf8Path, destination: &Utf8Path, depth: &str) -> Repo {
+        let url = url::Url::from_directory_path(source).unwrap();
+        git_in_dir(
+            source,
+            &[
+                "clone",
+                "--depth",
+                depth,
+                url.as_str(),
+                destination.as_str(),
+            ],
+        )
+        .unwrap();
+        Repo::new(destination).unwrap()
+    }
+
+    fn commit(repo: &Repo, name: &str) -> String {
+        fs_err::write(repo.directory().join(name), name).unwrap();
+        repo.add_all_and_commit(name).unwrap();
+        repo.current_commit_hash().unwrap()
+    }
+
+    #[test]
+    fn shallow_merge_requires_history_from_both_parents() {
+        let root = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(root.path()).unwrap();
+        let source = root.join("source");
+        fs_err::create_dir(&source).unwrap();
+        let repo = Repo::init(&source);
+        let initial = commit(&repo, "initial");
+        repo.checkout_new_branch("side").unwrap();
+        commit(&repo, "side-one");
+        let side = commit(&repo, "side-two");
+        repo.checkout_new_branch("release-line").unwrap();
+        repo.git(&["reset", "--hard", &initial]).unwrap();
+        let baseline = commit(&repo, "release");
+        repo.git(&["merge", "--no-ff", "side", "-m", "merge side"])
+            .unwrap();
+
+        let checkout = clone_shallow(&source, &root.join("checkout"), "2");
+        let history = ShallowHistory::new(&checkout).unwrap();
+        assert!(history.contains(&baseline));
+        assert!(history.contains(&side));
+        assert!(!history.is_complete_since(&checkout, &[&baseline]).unwrap());
+        let head = checkout.current_commit_hash().unwrap();
+        history.deepen(&checkout).unwrap();
+        assert_eq!(checkout.current_commit_hash().unwrap(), head);
+        assert!(
+            ShallowHistory::new(&checkout)
+                .unwrap()
+                .is_complete_since(&checkout, &[&baseline])
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn shallow_upstream_reports_no_progress() {
+        let root = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(root.path()).unwrap();
+        let source = root.join("source");
+        fs_err::create_dir(&source).unwrap();
+        let repo = Repo::init(&source);
+        commit(&repo, "initial");
+        commit(&repo, "latest");
+        let upstream = root.join("upstream");
+        clone_shallow(&source, &upstream, "1");
+        let checkout = clone_shallow(&upstream, &root.join("checkout"), "1");
+        let error = ShallowHistory::new(&checkout)
+            .unwrap()
+            .deepen(&checkout)
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("Fetching did not provide the missing git history"));
+    }
+
+    #[test]
+    fn linked_worktree_uses_shared_shallow_boundaries() {
+        let root = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(root.path()).unwrap();
+        let source = root.join("source");
+        fs_err::create_dir(&source).unwrap();
+        let repo = Repo::init(&source);
+        commit(&repo, "initial");
+        let latest = commit(&repo, "latest");
+        let checkout = clone_shallow(&source, &root.join("checkout"), "1");
+        let worktree_path = root.join("worktree");
+        checkout
+            .git(&["worktree", "add", "-b", "linked", worktree_path.as_str()])
+            .unwrap();
+        let worktree = Repo::new(&worktree_path).unwrap();
+        let history = ShallowHistory::new(&worktree).unwrap();
+        assert!(history.contains(&latest));
+        assert!(history.is_complete_since(&worktree, &[&latest]).unwrap());
+        history.deepen(&worktree).unwrap();
+        assert!(
+            ShallowHistory::new(&worktree)
+                .unwrap()
+                .is_complete_since(&worktree, &[])
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn unrelated_shallow_branch_does_not_require_fetching() {
+        let root = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(root.path()).unwrap();
+        let source = root.join("source");
+        fs_err::create_dir(&source).unwrap();
+        let repo = Repo::init(&source);
+        commit(&repo, "initial");
+        let baseline = commit(&repo, "release");
+        repo.checkout_new_branch("other").unwrap();
+        commit(&repo, "other");
+        let checkout = clone_shallow(&source, &root.join("checkout"), "1");
+        // Fetch a separate complete history without deepening the other branch.
+        checkout.git(&["fetch", "origin", &baseline]).unwrap();
+        checkout
+            .git(&["checkout", "-b", "released", &baseline])
+            .unwrap();
+        let history = ShallowHistory::new(&checkout).unwrap();
+        assert!(history.is_complete_since(&checkout, &[]).unwrap());
+    }
+}

--- a/crates/release_plz_core/src/lib.rs
+++ b/crates/release_plz_core/src/lib.rs
@@ -10,6 +10,7 @@ mod diff;
 mod download;
 pub mod fs_utils;
 mod git;
+mod git_history;
 pub mod http_client;
 mod lock_compare;
 mod next_ver;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -112,10 +112,22 @@ fn process_git_only_package(
         release_regex.to_string()
     );
 
-    let Some((release_tag, version)) = unreleased_project_repo
+    let mut release = unreleased_project_repo
         .get_release_tag(&release_regex, &package.name)
-        .context("get release tag")?
-    else {
+        .context("get release tag")?;
+    if release.is_none() {
+        let repo = git_cmd::Repo::new(input.local_manifest_dir()?)?;
+        if repo.git(&["rev-parse", "--is-shallow-repository"])? == "true" {
+            // Shallow clones can omit release tags. Resolve this before deciding
+            // that a git-only package has never been released.
+            repo.git(&["fetch", "--tags", "--no-recurse-submodules", repo.original_remote()])
+                .context("Failed to fetch release tags for the shallow repository. Fetch the release tags manually or set `fetch-depth: 0` in actions/checkout.")?;
+            release = unreleased_project_repo
+                .get_release_tag(&release_regex, &package.name)
+                .context("get fetched release tag")?;
+        }
+    }
+    let Some((release_tag, version)) = release else {
         info!(
             "No release tag found matching pattern `{release_regex}`. \
              Package {} will be treated as initial release.",
@@ -539,6 +551,297 @@ fn canonicalized_path(dependency: &dyn TableLike, package_dir: &Utf8Path) -> Opt
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn shallow_workspace_fetches_only_when_history_is_needed() {
+        use cargo_metadata::camino::Utf8Path;
+        use git_cmd::{Repo, git_in_dir};
+
+        let root = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(root.path()).unwrap();
+        let source = root.join("source");
+        fs_err::create_dir(&source).unwrap();
+        let source_repo = Repo::init(&source);
+        // Leave enough older history that deepening one batch does not turn
+        // the checkout into a full clone.
+        for _ in 0..60 {
+            source_repo
+                .git(&["commit", "--allow-empty", "-m", "older history"])
+                .unwrap();
+        }
+        fs_err::write(
+            source.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"one\", \"two\", \"three\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        for name in ["one", "two", "three"] {
+            fs_err::create_dir_all(source.join(name).join("src")).unwrap();
+            fs_err::write(
+                source.join(name).join("Cargo.toml"),
+                format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+            )
+            .unwrap();
+            fs_err::write(source.join(name).join("src/lib.rs"), "// initial\n").unwrap();
+        }
+        cargo_utils::get_manifest_metadata(&source.join("Cargo.toml")).unwrap();
+        source_repo.add_all_and_commit("initial packages").unwrap();
+        for name in ["one", "two", "three"] {
+            source_repo
+                .tag(&format!("{name}-v0.1.0"), "release")
+                .unwrap();
+        }
+
+        // A local registry snapshot keeps the test independent of network services.
+        let registry = root.join("registry");
+        git_in_dir(root, &["clone", source.as_str(), registry.as_str()]).unwrap();
+        for name in ["one", "two", "three"] {
+            fs_err::copy(
+                registry.join(name).join("Cargo.toml"),
+                registry.join(name).join("Cargo.toml.orig"),
+            )
+            .unwrap();
+        }
+
+        for (name, message) in [
+            ("one", "feat: first feature"),
+            ("one", "feat: second feature"),
+            ("two", "fix: second package"),
+            ("three", "chore: unrelated latest change"),
+        ] {
+            fs_err::write(
+                source.join(name).join("src/lib.rs"),
+                format!("// {message}\n"),
+            )
+            .unwrap();
+            source_repo.add_all_and_commit(message).unwrap();
+        }
+
+        let checkout = root.join("checkout");
+        let source_url = url::Url::from_directory_path(&source).unwrap();
+        git_in_dir(
+            root,
+            &["clone", "--depth=1", source_url.as_str(), checkout.as_str()],
+        )
+        .unwrap();
+        let request_for = |directory: &Utf8Path| {
+            let metadata =
+                cargo_utils::get_manifest_metadata(&directory.join("Cargo.toml")).unwrap();
+            super::UpdateRequest::new(metadata)
+                .unwrap()
+                .with_registry_manifest_path(&registry.join("Cargo.toml"))
+                .unwrap()
+                .with_default_package_config(
+                    crate::UpdateConfig::default().with_semver_check(false),
+                )
+        };
+        let request = request_for(&checkout);
+
+        // A shallow clone containing the release baseline works even offline.
+        let sufficient = root.join("sufficient");
+        git_in_dir(
+            root,
+            &[
+                "clone",
+                "--depth=5",
+                source_url.as_str(),
+                sufficient.as_str(),
+            ],
+        )
+        .unwrap();
+        let missing_remote = root.join("missing-remote");
+        git_in_dir(
+            &sufficient,
+            &["remote", "set-url", "origin", missing_remote.as_str()],
+        )
+        .unwrap();
+        crate::update(&request_for(&sufficient)).await.unwrap();
+        assert_eq!(
+            git_in_dir(&sufficient, &["rev-parse", "--is-shallow-repository"]).unwrap(),
+            "true"
+        );
+
+        // First releases can intentionally limit analysis. Enough history for
+        // that limit also works offline, without requiring the repository root.
+        let unpublished = root.join("unpublished");
+        git_in_dir(
+            root,
+            &[
+                "clone",
+                "--depth=4",
+                source_url.as_str(),
+                unpublished.as_str(),
+            ],
+        )
+        .unwrap();
+        git_in_dir(
+            &unpublished,
+            &["remote", "set-url", "origin", missing_remote.as_str()],
+        )
+        .unwrap();
+        let empty_registry = root.join("empty-registry");
+        fs_err::create_dir(&empty_registry).unwrap();
+        let empty_manifest = empty_registry.join("Cargo.toml");
+        fs_err::write(&empty_manifest, "[workspace]\nmembers = []\n").unwrap();
+        let first_release = request_for(&unpublished)
+            .with_registry_manifest_path(&empty_manifest)
+            .unwrap()
+            .with_max_analyze_commits(Some(1));
+        crate::update(&first_release).await.unwrap();
+        let first_changelog = fs_err::read_to_string(unpublished.join("one/CHANGELOG.md")).unwrap();
+        assert!(
+            first_changelog.contains("second feature"),
+            "{first_changelog}"
+        );
+        assert!(
+            !first_changelog.contains("first feature"),
+            "{first_changelog}"
+        );
+
+        git_in_dir(
+            &checkout,
+            &["remote", "set-url", "origin", missing_remote.as_str()],
+        )
+        .unwrap();
+
+        // Git may convert line endings during clone, so compare the checkout
+        // against its own contents before the update.
+        let manifests_before = ["one", "two", "three"].map(|name| {
+            let manifest = checkout.join(name).join("Cargo.toml");
+            (name, fs_err::read_to_string(manifest).unwrap())
+        });
+        let error = crate::update(&request).await.unwrap_err();
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("Failed to deepen the shallow repository"),
+            "{error}"
+        );
+        assert!(error.contains("git fetch --unshallow"), "{error}");
+        assert!(error.contains("fetch-depth: 0"), "{error}");
+        for (name, manifest_before) in manifests_before {
+            assert!(!checkout.join(name).join("CHANGELOG.md").exists());
+            assert_eq!(
+                fs_err::read_to_string(checkout.join(name).join("Cargo.toml")).unwrap(),
+                manifest_before
+            );
+        }
+
+        // Restoring access is sufficient: update fetches the missing history in
+        // its temporary copy and keeps the user's checkout shallow.
+        git_in_dir(
+            &checkout,
+            &["remote", "set-url", "origin", source_url.as_str()],
+        )
+        .unwrap();
+        let (_, repository) = crate::update(&request).await.unwrap();
+        assert_eq!(
+            repository
+                .repo
+                .git(&["rev-parse", "--is-shallow-repository"])
+                .unwrap(),
+            "true"
+        );
+        assert_eq!(
+            git_in_dir(&checkout, &["rev-list", "--count", "HEAD"]).unwrap(),
+            "1"
+        );
+        let one = fs_err::read_to_string(checkout.join("one/CHANGELOG.md")).unwrap();
+        assert!(one.contains("first feature"), "{one}");
+        assert!(one.contains("second feature"), "{one}");
+        assert!(!one.contains("unrelated latest change"), "{one}");
+        let two = fs_err::read_to_string(checkout.join("two/CHANGELOG.md")).unwrap();
+        assert!(two.contains("second package"), "{two}");
+        assert!(!two.contains("unrelated latest change"), "{two}");
+        let three = fs_err::read_to_string(checkout.join("three/CHANGELOG.md")).unwrap();
+        assert!(three.contains("unrelated latest change"), "{three}");
+        for name in ["one", "two", "three"] {
+            assert_eq!(
+                fs_err::read_to_string(checkout.join(name).join("CHANGELOG.md")).unwrap(),
+                fs_err::read_to_string(sufficient.join(name).join("CHANGELOG.md")).unwrap(),
+            );
+        }
+
+        // Missing tags in git-only mode must not turn a published package into
+        // an initial release. Discover the tags before reconstructing baselines.
+        let git_only = root.join("git-only");
+        git_in_dir(
+            root,
+            &["clone", "--depth=1", source_url.as_str(), git_only.as_str()],
+        )
+        .unwrap();
+        assert!(
+            git_in_dir(&git_only, &["tag", "--list"])
+                .unwrap()
+                .is_empty()
+        );
+        let config = crate::UpdateConfig {
+            git_only: Some(true),
+            semver_check: false,
+            ..crate::UpdateConfig::default()
+        };
+        crate::update(&request_for(&git_only).with_default_package_config(config))
+            .await
+            .unwrap();
+        for name in ["one", "two", "three"] {
+            assert_eq!(
+                fs_err::read_to_string(checkout.join(name).join("CHANGELOG.md")).unwrap(),
+                fs_err::read_to_string(git_only.join(name).join("CHANGELOG.md")).unwrap(),
+            );
+        }
+
+        // The previous release may already include merged history older than
+        // the package's last change. Neither shallow parent needs deepening.
+        let merged_source = root.join("merged-source");
+        git_in_dir(root, &["clone", source.as_str(), merged_source.as_str()]).unwrap();
+        let merged_repo = Repo::new(&merged_source).unwrap();
+        merged_repo
+            .git(&["config", "user.name", "author_name"])
+            .unwrap();
+        merged_repo
+            .git(&["config", "user.email", "author@example.com"])
+            .unwrap();
+        merged_repo.disable_gpg_signing().unwrap();
+        merged_repo.git(&["reset", "--hard", "one-v0.1.0"]).unwrap();
+        let baseline = merged_repo.current_commit_hash().unwrap();
+        merged_repo.checkout_new_branch("old-side").unwrap();
+        merged_repo.git(&["reset", "--hard", "HEAD~1"]).unwrap();
+        fs_err::write(merged_source.join("side.txt"), "older side branch").unwrap();
+        merged_repo.add_all_and_commit("older side change").unwrap();
+        merged_repo.checkout_new_branch("release-line").unwrap();
+        merged_repo.git(&["reset", "--hard", &baseline]).unwrap();
+        merged_repo
+            .git(&[
+                "merge",
+                "--no-ff",
+                "old-side",
+                "-m",
+                "previous release merge",
+            ])
+            .unwrap();
+        for name in ["one", "two", "three"] {
+            merged_repo
+                .git(&["tag", "-f", &format!("{name}-v0.1.0")])
+                .unwrap();
+        }
+        fs_err::write(merged_source.join("one/src/lib.rs"), "// new feature\n").unwrap();
+        merged_repo
+            .add_all_and_commit("feat: after merged release")
+            .unwrap();
+        let merged = root.join("merged");
+        let merged_url = url::Url::from_directory_path(&merged_source).unwrap();
+        git_in_dir(
+            root,
+            &["clone", "--depth=3", merged_url.as_str(), merged.as_str()],
+        )
+        .unwrap();
+        git_in_dir(
+            &merged,
+            &["remote", "set-url", "origin", missing_remote.as_str()],
+        )
+        .unwrap();
+        crate::update(&request_for(&merged)).await.unwrap();
+        let changelog = fs_err::read_to_string(merged.join("one/CHANGELOG.md")).unwrap();
+        assert!(changelog.contains("after merged release"), "{changelog}");
+    }
+
     #[test]
     fn reconstruction_preserves_existing_package_named_worktree() {
         // Create an initial commit so the worktrees have a branch target.

--- a/website/docs/usage/update.md
+++ b/website/docs/usage/update.md
@@ -24,3 +24,17 @@ unpublished changes.
 ![release-plz update](https://user-images.githubusercontent.com/11428655/160762832-54300ddb-ec9c-4538-a611-c66490c47333.gif)
 
 To learn more, run `release-plz update --help`.
+
+## Shallow clones
+
+`release-plz update` and `release-plz release-pr` can use shallow clones when
+the available history is sufficient to determine the changes for each package.
+If more history is needed, release-plz fetches it from the configured upstream
+remote in batches and retries the calculation. It also checks for missing history
+on merged branches. In `git_only` mode, a missing release tag triggers a tag fetch
+before the package is treated as an initial release.
+
+Automatic fetching uses your Git credentials. If fetching fails or the remote
+cannot provide more history, release-plz returns an error before updating versions
+or changelogs. You can fetch the history yourself with `git fetch --unshallow`,
+or configure `actions/checkout` with `fetch-depth: 0`.


### PR DESCRIPTION
A depth-one checkout can make Git attribute unrelated package files to the latest commit, omitting earlier changes from changelogs and potentially affecting version selection. Allow shallow checkouts when their available history is sufficient; fetch additional history when version calculation needs to cross a shallow boundary.

Replaces #3022. Its blanket rejection also fails checkouts that already contain all required release history. This approach preserves those workflows, including checkouts that can complete without remote access.

The calculation checks the release baseline before attributing changes to a shallow root. When history is missing, it deepens the temporary repository by 50 commits and retries the package calculation, since fetching can change the path-filtered commit selection. It checks ancestry on merged branches as well, while excluding history already covered by a release baseline. Fetch failures and successful fetches that supply no additional history return actionable errors before manifests or changelogs are updated. In `git_only` mode, missing release tags are fetched before treating a package as an initial release.

Regression coverage includes sufficient shallow history with an unreachable remote, automatic deepening without unshallowing the original checkout, unchanged manifests on fetch failure, first-release analysis limits, missing release tags, shallow merge parents, releases that already include merged history, linked-worktree boundary detection, and shallow upstreams that cannot provide more history. The three-package regression checks package-specific changelogs against a sufficient-history checkout.

Addresses the shallow-checkout failure from #2494. This does not replace the merge-history traversal work in #2940.

Validation:

- `cargo test -p release_plz_core -p git_cmd --all-features`: 113 passed, 3 existing network tests ignored.
- `cargo clippy -p release_plz_core -p git_cmd --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

Codex generated the implementation, regression tests, documentation, and this PR description following discussion of the compatibility problems with #3022. Codex ran the validation above. This draft is available for human review.
