### PR TITLE
fix(copy_dir): don't apply gitignore rules when copying the project

### DIFF
--- a/crates/release_plz_core/src/copy_dir.rs
+++ b/crates/release_plz_core/src/copy_dir.rs
@@ -53,9 +53,13 @@ fn copy_directory(from: &Utf8Path, to: &Utf8PathBuf) -> Result<(), anyhow::Error
         .hidden(false)
         // Don't consider `.ignore` files.
         .ignore(false)
-        // Ignore the global `.gitignore` as it might cause issues.
-        // For example, if it contains `.git/`, we will fail in recognizing the git directory later.
+        // Don't apply gitignore rules: we want a faithful copy. Unanchored
+        // patterns (e.g. `tags`) otherwise match paths inside `.git` (e.g.
+        // `.git/refs/tags`) and silently drop them.
+        .git_ignore(false)
         .git_global(false)
+        .git_exclude(false)
+        .parents(false)
         .build();
     for entry in walker {
         let entry = entry.context("invalid entry")?;
@@ -130,6 +134,29 @@ mod tests {
         let file1_dest = temp2.path().join(subdir).join("file1");
         assert!(file1_dest.exists());
         assert_eq!(link_target, file1_dest);
+    }
+
+    #[test]
+    fn gitignored_names_inside_git_dir_are_copied() {
+        let temp = Utf8TempDir::new().unwrap();
+        let src = temp.path().join("repo");
+        fs_err::create_dir(&src).unwrap();
+        fs_err::write(src.join(".gitignore"), "tags\n").unwrap();
+        let git_tags = src.join(".git").join("refs").join("tags");
+        fs_err::create_dir_all(&git_tags).unwrap();
+        fs_err::write(git_tags.join("v1.0.0"), "deadbeef").unwrap();
+
+        let temp2 = Utf8TempDir::new().unwrap();
+        copy_dir(&src, temp2.path()).unwrap();
+
+        let copied_tag = temp2
+            .path()
+            .join("repo")
+            .join(".git")
+            .join("refs")
+            .join("tags")
+            .join("v1.0.0");
+        assert!(copied_tag.exists(), "{copied_tag:?} was not copied");
     }
 
     #[test]


### PR DESCRIPTION
- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

I used an AI assistant to help draft the regression test and this description. I reviewed the change, understand it, and am responsible for its quality.

---

Closes #2973.

## What

`copy_directory` (used to copy the project into a temp dir before computing the next version) walks the source with `ignore::WalkBuilder`, which by default applies the repository's own `.gitignore`. Ignore patterns are unanchored unless they contain a slash, so a single line like `tags` (the first entry of GitHub's `Global/Tags.gitignore` template) expands to `**/tags` and matches `.git/refs/tags`. The copied repo ends up with no tags.

With `git_only = true`, tags are the only source for a package's last release, so every package looks like an initial release and `release-pr` concludes the repository is already up-to-date and opens nothing — silently.

## Fix

Disable gitignore handling in the walker (`git_ignore(false)`, `git_exclude(false)`, `parents(false)`, keeping the existing `git_global(false)`). The intent here is a faithful copy of the directory tree, so gitignore rules should not prune it. `.hidden(false)` and `.ignore(false)` were already set for the same reason.

## Tests

Added a unit test reproducing the exact mechanism from the issue: a source dir with `.gitignore` containing `tags` and a `.git/refs/tags/v1.0.0`, asserting the tag file is present after `copy_dir`.

## Validation

```
cargo test -p release_plz_core --lib copy_dir::tests
```

RED→GREEN verified genuine:
- Before the fix, `gitignored_names_inside_git_dir_are_copied` fails: `".../repo/.git/refs/tags/v1.0.0" was not copied`.
- After the fix, all 4 `copy_dir::tests` pass.

Also ran `cargo clippy -p release_plz_core --lib` (no warnings) and `cargo fmt -- --check` on the changed file (clean).

Happy to adjust.
