### PR TITLE
fix: release private git-only packages consistently

### DIFF
--- a/crates/fake_package/src/package.rs
+++ b/crates/fake_package/src/package.rs
@@ -6,6 +6,10 @@ use crate::dependency::FakeDependency;
 pub struct FakePackage {
     name: String,
     dependencies: Vec<FakeDependency>,
+    /// The `publish` field of the manifest, as Cargo reports it.
+    publish: Option<Vec<String>>,
+    /// Target kinds, such as `lib`, `bin` or `example`. One target per kind.
+    targets: Vec<String>,
 }
 
 impl FakePackage {
@@ -13,12 +17,40 @@ impl FakePackage {
         Self {
             name: name.into(),
             dependencies: vec![],
+            publish: None,
+            targets: vec![],
         }
     }
 
     pub fn with_dependencies(self, dependencies: Vec<FakeDependency>) -> Self {
         Self {
             dependencies,
+            ..self
+        }
+    }
+
+    /// Set the `publish` field of the package.
+    ///
+    /// `None` is the default (publishable anywhere), `Some(vec!["my-reg".into()])`
+    /// restricts the package to the listed registries. Use [`Self::unpublishable`]
+    /// for `publish = false`.
+    pub fn with_publish(self, publish: Option<Vec<String>>) -> Self {
+        Self { publish, ..self }
+    }
+
+    /// `publish = false` in `Cargo.toml`: the package can't be published anywhere.
+    pub fn unpublishable(self) -> Self {
+        Self {
+            publish: Some(vec![]),
+            ..self
+        }
+    }
+
+    /// Set the target kinds of the package, such as `lib`, `bin` or `example`.
+    /// By default the package has no targets.
+    pub fn with_targets(self, kinds: &[&str]) -> Self {
+        Self {
+            targets: kinds.iter().map(|kind| (*kind).to_string()).collect(),
             ..self
         }
     }
@@ -29,15 +61,61 @@ impl From<FakePackage> for Package {
         let dependencies: Vec<Dependency> =
             pkg.dependencies.into_iter().map(Dependency::from).collect();
         let name = pkg.name;
+        let targets: Vec<_> = pkg
+            .targets
+            .iter()
+            .map(|kind| {
+                serde_json::json!({
+                    "name": "t", "kind": [kind], "crate_types": [kind],
+                    "src_path": "/src/lib.rs", "edition": "2021", "doctest": false,
+                    "test": true, "doc": true,
+                })
+            })
+            .collect();
         serde_json::from_value(serde_json::json!({
             "name": name,
             "version": "0.1.0",
             "id": name,
+            "publish": pkg.publish,
             "dependencies": dependencies,
             "features": {},
             "manifest_path": format!("{name}/Cargo.toml"),
-            "targets": [],
+            "targets": targets,
         }))
         .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_package_has_no_publish_restriction_and_no_targets() {
+        let package = Package::from(FakePackage::new("pkg"));
+        assert_eq!(package.publish, None);
+        assert!(package.targets.is_empty());
+    }
+
+    #[test]
+    fn unpublishable_package_has_no_registries() {
+        let package = Package::from(FakePackage::new("pkg").unpublishable());
+        assert_eq!(package.publish, Some(vec![]));
+    }
+
+    #[test]
+    fn builders_set_publish_and_targets() {
+        let package = Package::from(
+            FakePackage::new("pkg")
+                .with_publish(Some(vec!["my-reg".into()]))
+                .with_targets(&["lib", "example"]),
+        );
+        assert_eq!(package.publish, Some(vec!["my-reg".to_string()]));
+        let kinds: Vec<_> = package
+            .targets
+            .iter()
+            .map(|t| t.kind[0].to_string())
+            .collect();
+        assert_eq!(kinds, ["lib", "example"]);
     }
 }

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -147,8 +147,8 @@ impl Config {
 fn validate_git_only_settings(git_only: Option<bool>, publish: Option<bool>) -> anyhow::Result<()> {
     if git_only == Some(true) && publish == Some(true) {
         anyhow::bail!(
-            "Config options 'git_only' and 'publish' are mutually exclusive. \
-            When git_only is enabled, publish must be explicitly set to false."
+            "Config options 'git_only' and 'publish' are mutually exclusive: \
+            git-only packages are never published, so remove `publish = true`."
         );
     }
     Ok(())
@@ -358,6 +358,9 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         }
         if let Some(allow_dirty) = value.publish_allow_dirty {
             cfg = cfg.with_allow_dirty(allow_dirty);
+        }
+        if let Some(git_only) = value.git_only {
+            cfg = cfg.with_git_only(git_only);
         }
         cfg
     }

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -1195,6 +1195,9 @@ publish = false
     );
 }
 
+/// With `git_only = true` and no explicit `publish` key, a `publish = false` crate
+/// goes through the `release-pr` -> `release` round trip: `release-pr` bumps it and
+/// `release` tags it without running `cargo publish`, which would refuse to publish it.
 #[tokio::test]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn git_only_processes_packages_with_publish_false_in_manifest() {
@@ -1209,7 +1212,8 @@ async fn git_only_processes_packages_with_publish_false_in_manifest() {
     cargo_toml.write().unwrap();
     context.push_all_changes("chore: set publish = false");
 
-    // Configure git_only = true in release-plz config
+    // Configure git_only = true in release-plz config.
+    // `publish` is not set: git-only mode must skip `cargo publish` on its own.
     let config = r#"
 [workspace]
 git_only = true
@@ -1231,6 +1235,13 @@ git_only = true
     let opened_prs = context.opened_release_prs().await;
     assert_eq!(opened_prs.len(), 1);
     assert_eq!(opened_prs[0].title, "chore: release v0.1.1");
+
+    // Release must tag the crate without running `cargo publish`.
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    context.repo.git(&["fetch", "--tags"]).unwrap();
+    assert!(context.repo.tag_exists("v0.1.1").unwrap());
 }
 
 #[tokio::test]
@@ -1294,4 +1305,13 @@ git_release_name = "{{ package }}-v{{ version }}"
     let pr_body = opened_prs[0].body.as_ref().expect("PR should have body");
     assert!(pr_body.contains("`mybin`: 0.1.0 -> 0.1.1"));
     assert!(pr_body.contains("update mybin readme"));
+
+    // The merged `[[package]]` override carries `publish = true` for mybin, which has
+    // `publish = false` in its manifest. Git-only packages are never published, so
+    // `release` must not reject that and must tag mybin.
+    context.merge_release_pr().await;
+    context.run_release().success();
+
+    context.repo.git(&["fetch", "--tags"]).unwrap();
+    assert!(context.repo.tag_exists("mybin-v0.1.1").unwrap());
 }

--- a/crates/release_plz/tests/all/git_only.rs
+++ b/crates/release_plz/tests/all/git_only.rs
@@ -1195,7 +1195,8 @@ publish = false
     );
 }
 
-/// With `git_only = true` and no explicit `publish` key, a `publish = false` crate
+/// With `git_only = true` and `publish` unset in release-plz.toml,
+/// a crate with `publish = false` in Cargo.toml
 /// goes through the `release-pr` -> `release` round trip: `release-pr` bumps it and
 /// `release` tags it without running `cargo publish`, which would refuse to publish it.
 #[tokio::test]

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -23,6 +23,7 @@ use crate::{
     cargo::{CargoRegistry, CmdOutput, is_published, run_cargo_with_env, wait_until_published},
     changelog_parser,
     git::forge::GitClient,
+    next_ver::takes_part_in_release,
     pr_parser::{Pr, prs_from_text},
 };
 
@@ -148,9 +149,23 @@ impl ReleaseRequest {
             })
     }
 
+    /// Return true if the package must be published to a cargo registry.
+    ///
+    /// Git-only packages are never published: their versions live in git tags only,
+    /// so `cargo publish` is skipped even if `publish` isn't explicitly disabled.
     fn is_publish_enabled(&self, package: &str) -> bool {
         let config = self.get_package_config(package);
-        config.publish.enabled
+        config.publish.enabled && !config.git_only
+    }
+
+    fn is_git_only(&self, package: &str) -> bool {
+        let config = self.get_package_config(package);
+        config.git_only
+    }
+
+    /// See [`takes_part_in_release`].
+    fn is_releasable(&self, package: &Package) -> bool {
+        takes_part_in_release(package, self.is_git_only(&package.name))
     }
 
     fn is_git_release_enabled(&self, package: &str) -> bool {
@@ -207,7 +222,9 @@ impl ReleaseRequest {
             return Ok(());
         }
         for package in &self.metadata.packages {
-            if !self.metadata.workspace_members.contains(&package.id) || !package.is_publishable() {
+            if !self.metadata.workspace_members.contains(&package.id)
+                || !self.is_releasable(package)
+            {
                 continue;
             }
             let config = self.get_package_config(&package.name);
@@ -226,6 +243,9 @@ impl ReleaseRequest {
     ///
     /// If there is no inconsistency, returns Ok(())
     ///
+    /// Git-only packages are skipped: they are never published, so the `publish`
+    /// field of their release-plz configuration is irrelevant.
+    ///
     /// # Errors
     ///
     /// Errors if any package has `publish = false` or `publish = []` in the Cargo.toml
@@ -235,6 +255,7 @@ impl ReleaseRequest {
 
         for package in &self.metadata.packages {
             if !package.is_publishable()
+                && !self.is_git_only(&package.name)
                 && let Some(should_publish) = publish_fields.get(package.name.as_str())
             {
                 anyhow::ensure!(
@@ -324,11 +345,20 @@ pub struct ReleaseConfig {
     /// Whether this package has a changelog that release-plz updates or not.
     /// Default: `true`.
     changelog_update: bool,
+    /// Whether the package versions are tracked with git tags instead of a cargo registry.
+    /// A `publish = false` package is only released when this is `true`.
+    /// Default: `false`.
+    git_only: bool,
 }
 
 impl ReleaseConfig {
     pub fn with_publish(mut self, publish: PublishConfig) -> Self {
         self.publish = publish;
+        self
+    }
+
+    pub fn with_git_only(mut self, git_only: bool) -> Self {
+        self.git_only = git_only;
         self
     }
 
@@ -399,6 +429,7 @@ impl Default for ReleaseConfig {
             release: true,
             changelog_path: None,
             changelog_update: true,
+            git_only: false,
         }
     }
 }
@@ -615,7 +646,11 @@ async fn release_packages(
     git_client: &GitClient,
 ) -> anyhow::Result<Option<Release>> {
     // Packages are already ordered by release order.
-    let packages = project.publishable_packages();
+    let packages: Vec<_> = project
+        .workspace_packages()
+        .into_iter()
+        .filter(|package| input.is_releasable(package))
+        .collect();
     if packages.is_empty() {
         info!("nothing to release");
     }
@@ -1294,7 +1329,7 @@ mod tests {
     use std::ffi::OsStr;
     use std::sync::{LazyLock, Mutex};
 
-    use fake_package::metadata::fake_metadata;
+    use fake_package::{FakePackage, metadata::fake_metadata};
 
     use super::*;
 
@@ -1341,18 +1376,36 @@ mod tests {
                 remote: remote.clone(),
             }),
         ] {
-            let mut metadata = fake_metadata();
-            // If validation is moved after repository access, the filesystem error will win.
-            let temp_dir = tempfile::tempdir().unwrap();
-            metadata.workspace_root =
-                Utf8PathBuf::from_path_buf(temp_dir.path().join("missing")).unwrap();
-            let request = ReleaseRequest::new(metadata)
-                .with_git_release(GitRelease { forge })
-                .with_default_package_config(ReleaseConfig::default().with_git_release(
-                    GitReleaseConfig::default().set_generate_release_notes(true),
-                ));
-            let error = release(&request).await.unwrap_err();
-            assert!(error.to_string().contains("git_release_generate_notes"));
+            for git_only in [false, true] {
+                let mut metadata = fake_metadata();
+                // Private packages still require validation when they are released in
+                // git-only mode.
+                if git_only {
+                    for package in &mut metadata.packages {
+                        package.publish = Some(vec![]);
+                    }
+                }
+                // If validation is moved after repository access, the filesystem error will win.
+                let temp_dir = tempfile::tempdir().unwrap();
+                metadata.workspace_root =
+                    Utf8PathBuf::from_path_buf(temp_dir.path().join("missing")).unwrap();
+                let request = ReleaseRequest::new(metadata)
+                    .with_git_release(GitRelease {
+                        forge: forge.clone(),
+                    })
+                    .with_default_package_config(
+                        ReleaseConfig::default()
+                            .with_git_only(git_only)
+                            .with_git_release(
+                                GitReleaseConfig::default().set_generate_release_notes(true),
+                            ),
+                    );
+                let error = release(&request).await.unwrap_err();
+                assert!(
+                    error.to_string().contains("git_release_generate_notes"),
+                    "git only: {git_only}: {error:#}"
+                );
+            }
         }
     }
 
@@ -1467,6 +1520,45 @@ mod tests {
     }
 
     #[test]
+    fn release_config_git_only_reaches_release_rule() {
+        // The full rule is covered by `packages_taking_part_in_a_release` in `next_ver.rs`;
+        // this only checks that the release config's `git_only` flag reaches it.
+        let pkg = Package::from(
+            FakePackage::new("pkg")
+                .unpublishable()
+                .with_targets(&["lib"]),
+        );
+        for git_only in [false, true] {
+            let request =
+                ReleaseRequest::new(fake_metadata()).with_default_package_config(ReleaseConfig {
+                    git_only,
+                    ..Default::default()
+                });
+            assert_eq!(
+                request.is_releasable(&pkg),
+                git_only,
+                "git only: {git_only}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_only_packages_are_never_published() {
+        for publish_enabled in [true, false] {
+            let request =
+                ReleaseRequest::new(fake_metadata()).with_default_package_config(ReleaseConfig {
+                    publish: PublishConfig::enabled(publish_enabled),
+                    git_only: true,
+                    ..Default::default()
+                });
+            assert!(
+                !request.is_publish_enabled("pkg"),
+                "publish enabled: {publish_enabled}"
+            );
+        }
+    }
+
+    #[test]
     fn check_publish_fields_works() {
         // fake_metadata() has `publish = false` in the Cargo.toml
         let mut request = ReleaseRequest::new(fake_metadata());
@@ -1479,5 +1571,23 @@ mod tests {
         );
 
         assert!(request.check_publish_fields().is_err());
+    }
+
+    #[test]
+    fn check_publish_fields_skips_git_only_packages() {
+        // fake_metadata() has `publish = false` in the Cargo.toml.
+        // The CLI merges `[[package]]` overrides with the `[workspace]` defaults, so an
+        // override for a git-only package carries `publish = true` even if the user
+        // never set `publish`. Git-only packages are never published, so this is fine.
+        let request = ReleaseRequest::new(fake_metadata()).with_package_config(
+            "fake_package".to_string(),
+            ReleaseConfig {
+                publish: PublishConfig::enabled(true),
+                git_only: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(request.check_publish_fields().is_ok());
     }
 }

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -29,6 +29,7 @@ use crate::{
     command::update::changelog_update::OldChangelogs,
     diff::{Commit, Diff},
     fs_utils, lock_compare,
+    next_ver::takes_part_in_release,
     registry_packages::{PackagesCollection, RegistryPackage},
     semver_check::{self, SemverCheck},
     toml_compare,
@@ -332,25 +333,13 @@ impl Updater<'_> {
         Ok(packages_diffs)
     }
 
+    /// See [`takes_part_in_release`].
     fn packages_to_process(&self) -> Vec<&Package> {
-        // Collect packages that are either publishable or git-only, with de-duplication, order is important.
-        let mut packages_to_process: Vec<&Package> = Vec::new();
-        let mut package_names: HashSet<String> = HashSet::new();
-
-        // Add publishable packages
-        for p in self.project.publishable_packages() {
-            if package_names.insert(p.name.to_string()) {
-                packages_to_process.push(p);
-            }
-        }
-
-        // Add git-only packages, not already added
-        for p in self.project.workspace_packages() {
-            if self.req.should_use_git_only(&p.name) && package_names.insert(p.name.to_string()) {
-                packages_to_process.push(p);
-            }
-        }
-        packages_to_process
+        self.project
+            .workspace_packages()
+            .into_iter()
+            .filter(|p| takes_part_in_release(p, self.req.should_use_git_only(&p.name)))
+            .collect()
     }
 
     async fn fill_commits<'a>(

--- a/crates/release_plz_core/src/lib.rs
+++ b/crates/release_plz_core/src/lib.rs
@@ -25,6 +25,8 @@ mod repo_url;
 mod response_ext;
 pub mod semver_check;
 mod tera;
+#[cfg(test)]
+mod test_utils;
 mod tmp_repo;
 mod toml_compare;
 mod url_utils;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -275,7 +275,10 @@ pub async fn next_versions(input: &UpdateRequest) -> anyhow::Result<(PackagesUpd
         .iter()
         .partition(|p| input.should_use_git_only(&p.name));
 
-    let is_multi_package = local_project.publishable_packages().len() > 1;
+    // Use the project's own answer: `Project` computes it before `--package` narrows
+    // the package set, and it is what the release command uses to create the tags we
+    // are about to look for.
+    let is_multi_package = local_project.contains_multiple_packages();
 
     // Process git_only packages (version determined from git tags).
     // Worktrees must be kept alive until we're done with the packages.
@@ -513,6 +516,25 @@ impl Publishable for Package {
     }
 }
 
+/// Whether the package takes part in a release.
+///
+/// This is the single rule shared by `release-plz update` and `release-plz release`, so
+/// that the packages bumped by one are exactly the packages tagged by the other:
+/// a package is released when it can be published to a registry, or when it is in
+/// `git_only` mode (its versions are tracked with git tags, so a `publish = false`
+/// package is tagged and gets a Git release).
+pub(crate) fn takes_part_in_release(package: &Package, git_only: bool) -> bool {
+    package.is_publishable() || (git_only && !is_unpublished_example(package))
+}
+
+/// An example-only package that doesn't set `publish` is not a crate anyone depends on,
+/// so it never takes part in a release, not even in git-only mode.
+/// Setting `publish` explicitly opts the package in.
+fn is_unpublished_example(package: &Package) -> bool {
+    package.publish.is_none() && is_example_package(package)
+}
+
+/// Whether all the targets of the package are examples.
 fn is_example_package(package: &Package) -> bool {
     package
         .targets
@@ -555,6 +577,38 @@ fn canonicalized_path(dependency: &dyn TableLike, package_dir: &Utf8Path) -> Opt
 
 #[cfg(test)]
 mod tests {
+    use fake_package::FakePackage;
+
+    #[test]
+    fn packages_taking_part_in_a_release() {
+        let lib = FakePackage::new("pkg").with_targets(&["lib"]);
+        let private_lib = lib.clone().unpublishable();
+        let example = FakePackage::new("pkg").with_targets(&["example"]);
+        let published_example = example.clone().with_publish(Some(vec!["my-reg".into()]));
+
+        // (name, package, released in registry mode, released in git-only mode)
+        for (name, package, registry, git_only) in [
+            ("lib", lib, true, true),
+            ("private lib", private_lib, false, true),
+            // Without `publish`, an example-only package is never a release candidate.
+            ("example", example, false, false),
+            // With `publish`, the user asked for it to be published (see the FAQ).
+            ("published example", published_example, true, true),
+        ] {
+            let package = cargo_metadata::Package::from(package);
+            assert_eq!(
+                super::takes_part_in_release(&package, false),
+                registry,
+                "{name} in registry mode"
+            );
+            assert_eq!(
+                super::takes_part_in_release(&package, true),
+                git_only,
+                "{name} in git-only mode"
+            );
+        }
+    }
+
     #[test]
     fn git_only_reconstructs_package_without_running_build_script() {
         let root = tempfile::tempdir().unwrap();

--- a/crates/release_plz_core/src/project.rs
+++ b/crates/release_plz_core/src/project.rs
@@ -32,9 +32,10 @@ pub struct Project {
     root: Utf8PathBuf,
     /// Directory containing the project manifest
     manifest_dir: Utf8PathBuf,
-    /// The project contains more than one public package.
-    /// Not affected by `single_package` option.
-    contains_multiple_pub_packages: bool,
+    /// Whether the project has more than one release-enabled package.
+    /// Computed before `--package` narrows the set, so that asking for a single
+    /// package doesn't change the tag names of a workspace.
+    contains_multiple_packages: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -77,7 +78,7 @@ impl Project {
             "no public packages found. Are there any public packages in your project? Analyzed packages: {packages_names:?}"
         );
 
-        let contains_multiple_pub_packages = packages.len() > 1;
+        let contains_multiple_packages = packages.len() > 1;
 
         if let Some(pac) = single_package {
             packages.retain(|p| *p.name == pac);
@@ -98,7 +99,7 @@ impl Project {
             release_metadata,
             root,
             manifest_dir,
-            contains_multiple_pub_packages,
+            contains_multiple_packages,
         })
     }
 
@@ -117,6 +118,13 @@ impl Project {
     /// Get all packages, including non-publishable.
     pub fn workspace_packages(&self) -> Vec<&Package> {
         self.packages.iter().collect()
+    }
+
+    /// Whether the project has more than one release-enabled package.
+    /// This decides the default tag name template, so the update and release
+    /// commands must answer it the same way.
+    pub(crate) fn contains_multiple_packages(&self) -> bool {
+        self.contains_multiple_packages
     }
 
     /// Copy this project in a temporary repository and return the repository.
@@ -162,8 +170,8 @@ impl Project {
             ),
         };
 
-        let template = template
-            .unwrap_or_else(|| default_tag_name_template(self.contains_multiple_pub_packages));
+        let template =
+            template.unwrap_or_else(|| default_tag_name_template(self.contains_multiple_packages));
 
         let context = tera_context(package_name, version);
         crate::tera::render_template(&template, &context, template_name)
@@ -427,6 +435,41 @@ mod tests {
         assert!(result.is_err());
         expect_test::expect![[r#"no public packages found. Are there any public packages in your project? Analyzed packages: ["cargo_utils", "fake_package", "git_cmd", "test_logs", "next_version", "release-plz", "release_plz_core"]"#]]
         .assert_eq(&result.unwrap_err().to_string());
+    }
+
+    #[test]
+    fn single_package_does_not_change_default_tag_template() {
+        let root = crate::fs_utils::Utf8TempDir::new().unwrap();
+        git_cmd::Repo::init(root.path());
+        fs_err::write(
+            root.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"one\", \"two\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        for name in ["one", "two"] {
+            crate::test_utils::write_package(&root.path().join(name), name, "0.1.0", "");
+        }
+        let manifest = root.path().join("Cargo.toml");
+        let workspace =
+            get_project(&manifest, None, &HashSet::default(), true, None, None).expect("Should ok");
+        assert_eq!(workspace.workspace_packages().len(), 2);
+        assert!(workspace.contains_multiple_packages());
+        assert_eq!(workspace.git_tag("one", "0.1.0").unwrap(), "one-v0.1.0");
+
+        // Narrowing the packages with `--package` must keep the tag names that the
+        // whole workspace creates, otherwise the release tags could not be found.
+        let narrowed = get_project(
+            &manifest,
+            Some("one"),
+            &HashSet::default(),
+            true,
+            None,
+            None,
+        )
+        .expect("Should ok");
+        assert_eq!(narrowed.workspace_packages().len(), 1);
+        assert!(narrowed.contains_multiple_packages());
+        assert_eq!(narrowed.git_tag("one", "0.1.0").unwrap(), "one-v0.1.0");
     }
 
     #[test]

--- a/crates/release_plz_core/src/semver_check.rs
+++ b/crates/release_plz_core/src/semver_check.rs
@@ -121,12 +121,7 @@ mod tests {
         let baseline = temp.path().join("baseline");
         let current = temp.path().join("current");
         for package in [&baseline, &current] {
-            fs_err::create_dir_all(package.join("src")).unwrap();
-            fs_err::write(
-                package.join(CARGO_TOML),
-                "[package]\nname = \"semver-check-test\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
-            )
-            .unwrap();
+            crate::test_utils::write_package(package, "semver-check-test", "1.0.0", "");
         }
         fs_err::write(baseline.join("src/lib.rs"), "pub fn answer() -> u32 { 42 }").unwrap();
 

--- a/crates/release_plz_core/src/test_utils.rs
+++ b/crates/release_plz_core/src/test_utils.rs
@@ -4,9 +4,9 @@ use cargo_metadata::camino::Utf8Path;
 use cargo_utils::CARGO_TOML;
 
 /// The manifest written by [`write_package`]: a `[package]` table with `name`,
-/// `version` and `edition = "2021"`, followed by `extra_toml`.
+/// `version` and `edition = "2024"`, followed by `extra_toml`.
 pub(crate) fn package_manifest(name: &str, version: &str, extra_toml: &str) -> String {
-    format!("[package]\nname = {name:?}\nversion = {version:?}\nedition = \"2021\"\n{extra_toml}")
+    format!("[package]\nname = {name:?}\nversion = {version:?}\nedition = \"2024\"\n{extra_toml}")
 }
 
 /// Write a minimal library package to `dir`: an empty `src/lib.rs` and the manifest

--- a/crates/release_plz_core/src/test_utils.rs
+++ b/crates/release_plz_core/src/test_utils.rs
@@ -1,0 +1,22 @@
+//! Helpers to scaffold Cargo packages on disk in unit tests.
+
+use cargo_metadata::camino::Utf8Path;
+use cargo_utils::CARGO_TOML;
+
+/// The manifest written by [`write_package`]: a `[package]` table with `name`,
+/// `version` and `edition = "2021"`, followed by `extra_toml`.
+pub(crate) fn package_manifest(name: &str, version: &str, extra_toml: &str) -> String {
+    format!("[package]\nname = {name:?}\nversion = {version:?}\nedition = \"2021\"\n{extra_toml}")
+}
+
+/// Write a minimal library package to `dir`: an empty `src/lib.rs` and the manifest
+/// returned by [`package_manifest`].
+pub(crate) fn write_package(dir: &Utf8Path, name: &str, version: &str, extra_toml: &str) {
+    fs_err::create_dir_all(dir.join("src")).unwrap();
+    fs_err::write(dir.join("src/lib.rs"), "").unwrap();
+    fs_err::write(
+        dir.join(CARGO_TOML),
+        package_manifest(name, version, extra_toml),
+    )
+    .unwrap();
+}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -406,9 +406,12 @@ When `git_only` is enabled:
 - Version detection is based on git tags matching the
   [`git_tag_name`](#the-git_tag_name-field) pattern.
 - If no matching tag is found, the package is treated as an initial release.
+- Packages with `publish = false` in their `Cargo.toml` are also released (tagged), since
+  they don't need a cargo registry.
 
 :::warning
-`git_only` and `publish` cannot both be `true` for the same package.
+In git-only mode `cargo publish` is skipped, so `publish` doesn't need to be set.
+Setting `publish = true` together with `git_only = true` is an error.
 :::
 
 Example:


### PR DESCRIPTION
Private packages selected by `git_only = true` can be bumped by `update` but skipped or rejected by `release`. Share the release-candidate rule between both commands, skip registry publishing and publish-field validation for Git-only packages, and validate the Git release options of private packages.

Use the same workspace package count for tag discovery and tag creation, including when `--package` narrows the selection. Keep implicit example-only packages out of releases. Includes the configuration documentation, package fixtures, release-rule unit tests, and existing integration tests extended through tagging.


- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

made with astra + fable 5.1. refined and reviewed by me.
